### PR TITLE
fix: remove stray plus sign in SwipeableTaskItem

### DIFF
--- a/src/components/SwipeableTaskItem/SwipeableTaskItem.js
+++ b/src/components/SwipeableTaskItem/SwipeableTaskItem.js
@@ -217,7 +217,7 @@ export default function SwipeableTaskItem({
               {task.difficulty}
             </Text>
           </View>
-          + {/* Prioridad (chip con borde) */}
+          {/* Prioridad (chip con borde) */}
           <View
             style={[
               styles.priorityChip,


### PR DESCRIPTION
## Summary
- remove stray character before priority comment in SwipeableTaskItem

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897b915799c83278cd4c15dc11a1dd5