### PR TITLE
fix: remove outdated agua color reference

### DIFF
--- a/src/components/SwipeableTaskItem/SwipeableTaskItem.styles.js
+++ b/src/components/SwipeableTaskItem/SwipeableTaskItem.styles.js
@@ -129,7 +129,6 @@ export default StyleSheet.create({
     width: 22,
     height: 22,
     borderRadius: 8,
-    color: Colors.agua,
     alignItems: "center",
     justifyContent: "center",
     marginRight: Spacing.small,


### PR DESCRIPTION
## Summary
- remove invalid `Colors.agua` reference from element badge styles

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897bac3d6c88327b737284d945e246d