### PR TITLE
fix: use valid priority key

### DIFF
--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -68,7 +68,7 @@ export default function TasksScreen() {
       isDeleted: false,
       type: "single",
       element: "fire",
-      priority: "high",
+      priority: "pending",
       tags: ["personal"],
       difficulty: "hard",
     },
@@ -101,7 +101,7 @@ export default function TasksScreen() {
   // Estados extra en el modal de creación
   const [newType, setNewType] = useState("single"); // 'single' | 'habit'
   const [newElement, setNewElement] = useState("all"); // 'all' | 'water' | 'earth' | ...
-  const [newPriority, setNewPriority] = useState("all"); // 'all' | 'urgent' | 'pending' | ...
+  const [newPriority, setNewPriority] = useState("all"); // 'all' | 'urgent' | 'pending' | 'relevant'
   // ➕ Estados para etiquetas en modal
   const [newTagInput, setNewTagInput] = useState("");
   const [newTags, setNewTags] = useState([]);


### PR DESCRIPTION
## Summary
- use "pending" priority for the sample task
- document full set of priority options when creating tasks

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897bac6e4b8832782ad9b7ccbbfd341