### PR TITLE
Fix swipe misactivation during vertical scroll

### DIFF
--- a/src/components/SwipeableTaskItem/SwipeableTaskItem.js
+++ b/src/components/SwipeableTaskItem/SwipeableTaskItem.js
@@ -74,8 +74,9 @@ export default function SwipeableTaskItem({
   // se usa useRef para evitar recrear el objeto en cada render
   const panResponder = useRef(
     PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponder: (_, gs) => Math.abs(gs.dx) > 5,
+      onStartShouldSetPanResponder: () => false,
+      onMoveShouldSetPanResponder: (_, gs) =>
+        Math.abs(gs.dx) > Math.abs(gs.dy) && Math.abs(gs.dx) > 5,
       onPanResponderMove: Animated.event([null, { dx: pan }], {
         useNativeDriver: false,
       }),


### PR DESCRIPTION
## Summary
- Restrict swipe gestures to horizontal movement and ignore initial tap captures

## Testing
- `npm test` (fails: Missing script: "test")
- `node -e const fn = (_, gs) => Math.abs(gs.dx) > Math.abs(gs.dy) && Math.abs(gs.dx) > 5; console.log('horizontal 10,0 =>', fn(null,{dx:10,dy:0})); console.log('vertical 0,10 =>', fn(null,{dx:0,dy:10})); console.log('diagonal 10,6 =>', fn(null,{dx:10,dy:6})); console.log('small horiz 3,0 =>', fn(null,{dx:3,dy:0}));`

------
https://chatgpt.com/codex/tasks/task_e_6897c09dc7b083279d3f8e9c61851d96