### PR TITLE
refactor: replace hex colors with tokens

### DIFF
--- a/src/components/AddTaskButton/AddTaskButton.styles.js
+++ b/src/components/AddTaskButton/AddTaskButton.styles.js
@@ -11,10 +11,10 @@ export default StyleSheet.create({
     width: 60,
     height: 60,
     borderRadius: 30,
-    backgroundColor: "#00B4D8", // Celeste vibrante moderno
+    backgroundColor: Colors.primary, // Celeste vibrante moderno
     justifyContent: "center",
     alignItems: "center",
-    shadowColor: "#000",
+    shadowColor: Colors.background,
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 6,

--- a/src/components/AdvancedFilters/AdvancedFilters.styles.js
+++ b/src/components/AdvancedFilters/AdvancedFilters.styles.js
@@ -30,7 +30,7 @@ export default StyleSheet.create({
     borderWidth: 0.5,
     borderColor: Colors.text,
     marginRight: Spacing.small,
-    backgroundColor: "#222a36", // Color base para todos los botones
+    backgroundColor: Colors.surface, // Color base para todos los botones
   },
   text: {
     color: Colors.text,

--- a/src/components/StatsHeader.js
+++ b/src/components/StatsHeader.js
@@ -37,7 +37,7 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.surface,
     borderRadius: 12,
     marginBottom: Spacing.small,
-    shadowColor: "#000",
+    shadowColor: Colors.background,
     paddingBottom: Spacing.base,
   },
   row: {

--- a/src/components/SwipeableTaskItem/SwipeableTaskItem.js
+++ b/src/components/SwipeableTaskItem/SwipeableTaskItem.js
@@ -114,10 +114,10 @@ export default function SwipeableTaskItem({
                 extrapolate: "clamp",
               }),
               backgroundColor: isDeletedView
-                ? "#87a4edff" // Restaurar: azul pastel
+                ? Colors.elementWater // Restaurar: azul pastel
                 : isCompletedView
-                ? "#92de71ff" // Completar: verde pastel
-                : "#92de71ff", // Completar: verde pastel (default)
+                ? Colors.secondary // Completar: verde pastel
+                : Colors.secondary, // Completar: verde pastel (default)
             },
           ]}
         >
@@ -142,8 +142,8 @@ export default function SwipeableTaskItem({
                 extrapolate: "clamp",
               }),
               backgroundColor: isDeletedView
-                ? "#FF8A80" // Borrar permanente: rojo pastel
-                : "#be6a69ff", // Borrar (soft): amarillo pastel
+                ? Colors.danger // Borrar permanente: rojo pastel
+                : Colors.accent, // Borrar (soft): amarillo pastel
             },
           ]}
         >

--- a/src/components/SwipeableTaskItem/SwipeableTaskItem.styles.js
+++ b/src/components/SwipeableTaskItem/SwipeableTaskItem.styles.js
@@ -45,7 +45,7 @@ export default StyleSheet.create({
     borderRadius: Spacing.small,
     padding: Spacing.base,
     borderLeftWidth: 2,
-    shadowColor: "#000",
+    shadowColor: Colors.background,
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.25,
     shadowRadius: 3.84,
@@ -134,7 +134,7 @@ export default StyleSheet.create({
     marginRight: Spacing.small,
     marginTop: 1,
     // opcional: un poco de relieve
-    shadowColor: "#000",
+    shadowColor: Colors.background,
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.2,
     shadowRadius: 1.5,


### PR DESCRIPTION
## Summary
- replace stray hex values with theme Colors tokens
- use background color token for shadows and buttons

## Testing
- `npm test` (fails: Missing script "test")
- `npm start` (fails: TypeError: fetch failed)


------
https://chatgpt.com/codex/tasks/task_e_6897c364b1b48327be05fc9fd8746691