### PR TITLE
feat: refresh mystical color palette

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -1,17 +1,17 @@
 // src/theme.js
 export const Colors = {
-  background: "#0F121A", // color definitivo
-  surface: "#1E2735",
-  primary: "#4CAF50",
-  secondary: "#8BC34A",
-  accent: "#FFC107",
-  danger: "#FF6347",
+  background: "#0e0a1e", // Fondo oscuro profundo
+  surface: "#1b1231", // Superficie ligeramente más clara
+  primary: "#7e57c2", // Púrpura místico
+  secondary: "#4dd0e1", // Turquesa etéreo
+  accent: "#ffca28", // Dorado suave para acentos
+  danger: "#ef5350", // Rojo armónico
   text: "#FFFFFF",
-  textMuted: "#5C7A8F",
-  elementWater: "#4FC3F7",
-  elementEarth: "#8BC34A",
-  elementFire: "#E57373",
-  elementAir: "#BDBDBD",
+  textMuted: "#b0bec5", // Texto atenuado acorde con la paleta
+  elementFire: "#ff7043",
+  elementWater: "#29b6f6",
+  elementEarth: "#8d6e63",
+  elementAir: "#90a4ae",
 };
 
 export const Spacing = {


### PR DESCRIPTION
## Summary
- adopt a dark mystical theme with new primary, secondary, and elemental colors
- tune accent, danger, and textMuted to harmonize with the palette

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6897c363d70083279f12e5e213b73bb0