### PR TITLE
refactor: centralize style colors in theme

### DIFF
--- a/src/components/AddTaskButton/AddTaskButton.styles.js
+++ b/src/components/AddTaskButton/AddTaskButton.styles.js
@@ -10,11 +10,11 @@ export default StyleSheet.create({
     right: Spacing.large,
     width: 60,
     height: 60,
-    borderRadius: 30,
-    backgroundColor: "#00B4D8", // Celeste vibrante moderno
-    justifyContent: "center",
-    alignItems: "center",
-    shadowColor: "#000",
+      borderRadius: 30,
+      backgroundColor: Colors.buttonBg, // Celeste vibrante moderno
+      justifyContent: "center",
+      alignItems: "center",
+      shadowColor: Colors.shadow,
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 6,

--- a/src/components/AdvancedFilters/AdvancedFilters.styles.js
+++ b/src/components/AdvancedFilters/AdvancedFilters.styles.js
@@ -30,7 +30,7 @@ export default StyleSheet.create({
     borderWidth: 0.5,
     borderColor: Colors.text,
     marginRight: Spacing.small,
-    backgroundColor: "#222a36", // Color base para todos los botones
+      backgroundColor: Colors.filterBtnBg, // Color base para todos los botones
   },
   text: {
     color: Colors.text,

--- a/src/components/SwipeableTaskItem/SwipeableTaskItem.styles.js
+++ b/src/components/SwipeableTaskItem/SwipeableTaskItem.styles.js
@@ -45,7 +45,7 @@ export default StyleSheet.create({
     borderRadius: Spacing.small,
     padding: Spacing.base,
     borderLeftWidth: 2,
-    shadowColor: "#000",
+      shadowColor: Colors.shadow,
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.25,
     shadowRadius: 3.84,
@@ -134,7 +134,7 @@ export default StyleSheet.create({
     marginRight: Spacing.small,
     marginTop: 1,
     // opcional: un poco de relieve
-    shadowColor: "#000",
+      shadowColor: Colors.shadow,
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.2,
     shadowRadius: 1.5,

--- a/src/theme.js
+++ b/src/theme.js
@@ -8,6 +8,9 @@ export const Colors = {
   danger: "#FF6347",
   text: "#FFFFFF",
   textMuted: "#5C7A8F",
+  buttonBg: "#00B4D8", // Celeste vibrante moderno
+  filterBtnBg: "#222a36", // Color base para botones de filtro
+  shadow: "#000000", // Color para sombras
   elementWater: "#4FC3F7",
   elementEarth: "#8BC34A",
   elementFire: "#E57373",


### PR DESCRIPTION
## Summary
- move hard-coded style colors into theme tokens
- replace inline hex values in style sheets with Colors tokens

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6897c362e9f8832793e04096c5e65948