### PR TITLE
Refactor advanced filter button styles

### DIFF
--- a/src/components/AdvancedFilters/AdvancedFilters.js
+++ b/src/components/AdvancedFilters/AdvancedFilters.js
@@ -35,7 +35,7 @@ export default function AdvancedFilters({
           return (
             <TouchableOpacity
               key={el.key}
-              style={[styles.btn, isActive && { backgroundColor: el.color }]}
+              style={[styles.elementBtn, isActive && { backgroundColor: el.color }]}
               onPress={() => setElementFilter(isActive ? "all" : el.key)}
             >
               <FontAwesome5
@@ -61,7 +61,7 @@ export default function AdvancedFilters({
           return (
             <TouchableOpacity
               key={opt.key}
-              style={[styles.btn, isActive && { backgroundColor: opt.color }]}
+              style={[styles.priorityBtn, isActive && { backgroundColor: opt.color }]}
               onPress={() => setPriorityFilter(isActive ? "all" : opt.key)}
             >
               <Text
@@ -83,7 +83,7 @@ export default function AdvancedFilters({
             <TouchableOpacity
               key={opt.key}
               style={[
-                styles.btn,
+                styles.difficultyBtn,
                 isActive && {
                   backgroundColor: opt.color,
                   borderColor: opt.color,
@@ -115,7 +115,7 @@ export default function AdvancedFilters({
             <TouchableOpacity
               key={tag}
               style={[
-                styles.btn,
+                styles.tagBtn,
                 isActive && { backgroundColor: Colors.accent },
               ]}
               onPress={() => setTagFilter(isActive ? "all" : tag)}

--- a/src/components/AdvancedFilters/AdvancedFilters.styles.js
+++ b/src/components/AdvancedFilters/AdvancedFilters.styles.js
@@ -3,6 +3,17 @@
 import { StyleSheet } from "react-native";
 import { Colors, Spacing } from "../../theme";
 
+const baseBtn = {
+  flexDirection: "row",
+  alignItems: "center",
+  padding: Spacing.tiny,
+  paddingHorizontal: Spacing.small,
+  borderRadius: 8,
+  borderWidth: 0.5,
+  borderColor: Colors.text,
+  marginRight: Spacing.small,
+};
+
 export default StyleSheet.create({
   container: {
     backgroundColor: Colors.surface,
@@ -21,16 +32,21 @@ export default StyleSheet.create({
     flexDirection: "row",
     marginBottom: Spacing.base,
   },
-  btn: {
-    flexDirection: "row",
-    alignItems: "center",
-    padding: Spacing.tiny,
-    paddingHorizontal: Spacing.small,
-    borderRadius: 8,
-    borderWidth: 0.5,
-    borderColor: Colors.text,
-    marginRight: Spacing.small,
-    backgroundColor: "#222a36", // Color base para todos los botones
+  elementBtn: {
+    ...baseBtn,
+    backgroundColor: Colors.buttonBg,
+  },
+  priorityBtn: {
+    ...baseBtn,
+    backgroundColor: Colors.buttonBg,
+  },
+  difficultyBtn: {
+    ...baseBtn,
+    backgroundColor: Colors.buttonBg,
+  },
+  tagBtn: {
+    ...baseBtn,
+    backgroundColor: Colors.buttonBg,
   },
   text: {
     color: Colors.text,

--- a/src/theme.js
+++ b/src/theme.js
@@ -8,6 +8,7 @@ export const Colors = {
   danger: "#FF6347",
   text: "#FFFFFF",
   textMuted: "#5C7A8F",
+  buttonBg: "#222a36",
   elementWater: "#4FC3F7",
   elementEarth: "#8BC34A",
   elementFire: "#E57373",


### PR DESCRIPTION
## Summary
- split generic filter button style into element, priority, difficulty, and tag variants
- add `Colors.buttonBg` theme token and apply to new button styles
- update AdvancedFilters component to use group-specific styles

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897c360cac88327827dfc71f4eed8aa