### PR TITLE
fix: restore AdvancedFilters component

### DIFF
--- a/src/components/AdvancedFilters/AdvancedFilters.js
+++ b/src/components/AdvancedFilters/AdvancedFilters.js
@@ -1,56 +1,104 @@
-// src/components/AdvancedFilters/AdvancedFilters.styles.js
+// src/components/AdvancedFilters/AdvancedFilters.js
 
-import { StyleSheet } from "react-native";
-import { Colors, Spacing } from "../../theme";
+import React from "react";
+import { View, Text, TouchableOpacity, ScrollView } from "react-native";
+import { FontAwesome5 } from "@expo/vector-icons";
+import styles from "./AdvancedFilters.styles";
+import { Colors } from "../../theme";
 
-// Un solo estilo base para todos los botones.
-const baseBtn = {
-  flexDirection: "row",
-  alignItems: "center",
-  padding: Spacing.tiny,
-  paddingHorizontal: Spacing.small,
-  borderRadius: 8,
-  borderWidth: 0.5,
-  borderColor: Colors.text,
-  marginRight: Spacing.small,
-  backgroundColor: Colors.buttonBg, // Color base para todos los botones de filtro
-};
+function renderRow(options, activeKey, setActive, baseStyle, overrideStyle) {
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      style={styles.row}
+    >
+      {options.map((opt) => {
+        const isActive = activeKey === opt.key;
+        return (
+          <TouchableOpacity
+            key={opt.key}
+            style={[
+              baseStyle,
+              overrideStyle,
+              isActive && {
+                backgroundColor: opt.color,
+                borderColor: opt.color,
+              },
+            ]}
+            onPress={() => setActive(opt.key)}
+          >
+            {opt.icon && (
+              <FontAwesome5
+                name={opt.icon}
+                size={14}
+                color={isActive ? Colors.background : opt.color}
+              />
+            )}
+            <Text
+              style={[
+                styles.text,
+                isActive && { color: Colors.background },
+              ]}
+            >
+              {opt.label}
+            </Text>
+          </TouchableOpacity>
+        );
+      })}
+    </ScrollView>
+  );
+}
 
-export default StyleSheet.create({
-  container: {
-    backgroundColor: Colors.surface,
-    borderRadius: 12,
-    padding: Spacing.base,
-    marginTop: 0,
-    marginBottom: Spacing.small,
-  },
-  title: {
-    color: Colors.text,
-    fontSize: 16,
-    fontWeight: "600",
-    marginBottom: Spacing.small,
-  },
-  row: {
-    flexDirection: "row",
-    marginBottom: Spacing.base,
-  },
-  // Se define una sola vez el estilo para cada tipo de botón,
-  // heredando las propiedades del estilo base.
-  elementBtn: {
-    ...baseBtn,
-  },
-  priorityBtn: {
-    ...baseBtn,
-  },
-  difficultyBtn: {
-    ...baseBtn,
-  },
-  tagBtn: {
-    ...baseBtn,
-  },
-  text: {
-    color: Colors.text,
-    fontSize: 14,
-    marginLeft: Spacing.small,
-  },
-});
+export default function AdvancedFilters({
+  elementOptions = [],
+  elementFilter,
+  setElementFilter,
+  priorityOptions = [],
+  priorityFilter,
+  setPriorityFilter,
+  difficultyOptions = [],
+  difficultyFilter,
+  setDifficultyFilter,
+  tags = [],
+  tagFilter,
+  setTagFilter,
+  elementBtnStyle,
+  priorityBtnStyle,
+  difficultyBtnStyle,
+  tagBtnStyle,
+}) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Filtros avanzados</Text>
+      {renderRow(
+        elementOptions,
+        elementFilter,
+        setElementFilter,
+        styles.elementBtn,
+        elementBtnStyle
+      )}
+      {renderRow(
+        priorityOptions,
+        priorityFilter,
+        setPriorityFilter,
+        styles.priorityBtn,
+        priorityBtnStyle
+      )}
+      {renderRow(
+        difficultyOptions,
+        difficultyFilter,
+        setDifficultyFilter,
+        styles.difficultyBtn,
+        difficultyBtnStyle
+      )}
+      {renderRow(
+        tags.map((tag) => ({ key: tag, label: tag, color: Colors.accent })),
+        tagFilter,
+        setTagFilter,
+        styles.tagBtn,
+        tagBtnStyle
+      )}
+    </View>
+  );
+}

--- a/src/components/AdvancedFilters/AdvancedFilters.styles.js
+++ b/src/components/AdvancedFilters/AdvancedFilters.styles.js
@@ -12,7 +12,7 @@ const baseBtn = {
   borderWidth: 0.5,
   borderColor: Colors.text,
   marginRight: Spacing.small,
-  backgroundColor: "#222a36", // Color base para todos los botones
+  backgroundColor: Colors.filterBtnBg,
 };
 
 export default StyleSheet.create({
@@ -33,37 +33,17 @@ export default StyleSheet.create({
     flexDirection: "row",
     marginBottom: Spacing.base,
   },
-  // Estilo base reutilizado por todos los botones de filtro
-  elementBtn: baseBtn,
-  priorityBtn: baseBtn,
-  difficultyBtn: baseBtn,
-  tagBtn: baseBtn,
   elementBtn: {
     ...baseBtn,
-    backgroundColor: Colors.buttonBg,
   },
   priorityBtn: {
     ...baseBtn,
-    backgroundColor: Colors.buttonBg,
   },
   difficultyBtn: {
     ...baseBtn,
-    backgroundColor: Colors.buttonBg,
   },
   tagBtn: {
     ...baseBtn,
-    backgroundColor: Colors.buttonBg,
-  btn: {
-    flexDirection: "row",
-    alignItems: "center",
-    padding: Spacing.tiny,
-    paddingHorizontal: Spacing.small,
-    borderRadius: 8,
-    borderWidth: 0.5,
-    borderColor: Colors.text,
-    marginRight: Spacing.small,
-      backgroundColor: Colors.filterBtnBg, // Color base para todos los botones
-
   },
   text: {
     color: Colors.text,

--- a/src/theme.js
+++ b/src/theme.js
@@ -7,19 +7,14 @@ export const Colors = {
   accent: "#ffca28", // Dorado suave para acentos
   danger: "#ef5350", // Rojo armónico
   text: "#FFFFFF",
-  textMuted: "#5C7A8F",
+  textMuted: "#b0bec5", // Texto atenuado acorde con la paleta
   buttonBg: "#00B4D8", // Celeste vibrante moderno
   filterBtnBg: "#222a36", // Color base para botones de filtro
   shadow: "#000000", // Color para sombras
 
-  elementWater: "#4FC3F7",
-  elementEarth: "#8BC34A",
-  elementFire: "#E57373",
-  elementAir: "#BDBDBD",
-  textMuted: "#b0bec5", // Texto atenuado acorde con la paleta
-  elementFire: "#ff7043",
   elementWater: "#29b6f6",
   elementEarth: "#8d6e63",
+  elementFire: "#ff7043",
   elementAir: "#90a4ae",
 };
 


### PR DESCRIPTION
## Summary
- implement missing `AdvancedFilters` component with customizable filter buttons
- clean up advanced filter styles and theme color definitions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897ce82cb5c8327b98840be34651c5c