### PR TITLE
fix: remove hardcoded difficulty in new tasks

### DIFF
--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -130,7 +130,6 @@ export default function TasksScreen() {
       element: newElement,
       priority: newPriority,
       tags: newTags.length > 0 ? newTags : [], // si hay etiquetas, las usamos
-      difficulty: "easy",
       difficulty: newDifficulty, // dificultad por defecto
     };
     // Añadimos la nueva tarea al estado


### PR DESCRIPTION
## Summary
- remove redundant `difficulty: "easy"` from new task creation to honor chosen difficulty

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_6897d8a7a6b88327bec28ce88bde340c