### PR TITLE
feat: refine task type buttons

### DIFF
--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -105,6 +105,11 @@ export default function TasksScreen() {
   // ➕ Estados para etiquetas en modal
   const [newTagInput, setNewTagInput] = useState("");
   const [newTags, setNewTags] = useState([]);
+  // Opciones del tipo de tarea
+  const typeOptions = [
+    { key: "single", label: "Tarea", activeColor: Colors.primaryLight },
+    { key: "habit", label: "Hábito", activeColor: Colors.secondaryLight },
+  ];
   // Opciones de dificultad
   const difficultyOptions = [
     { key: "easy", label: "Fácil", color: Colors.secondary },
@@ -301,24 +306,25 @@ export default function TasksScreen() {
             {/* Tipo de tarea */}
             <Text style={modalStyles.label}>Tipo</Text>
             <View style={modalStyles.row}>
-              {["single", "habit"].map((typeKey) => {
-                const active = newType === typeKey;
+              {typeOptions.map((opt, index) => {
+                const active = newType === opt.key;
                 return (
                   <TouchableOpacity
-                    key={typeKey}
+                    key={opt.key}
                     style={[
-                      modalStyles.optionBtn,
-                      active && { backgroundColor: Colors.primary },
+                      modalStyles.typeOptionBtn,
+                      index === typeOptions.length - 1 && { marginRight: 0 },
+                      active && { backgroundColor: opt.activeColor },
                     ]}
-                    onPress={() => setNewType(typeKey)}
+                    onPress={() => setNewType(opt.key)}
                   >
                     <Text
                       style={[
-                        modalStyles.optionText,
+                        modalStyles.typeOptionText,
                         active && { color: Colors.background },
                       ]}
                     >
-                      {typeKey === "single" ? "Única" : "Hábito"}
+                      {opt.label}
                     </Text>
                   </TouchableOpacity>
                 );

--- a/src/screens/TasksScreen.styles.js
+++ b/src/screens/TasksScreen.styles.js
@@ -80,6 +80,22 @@ export const modalStyles = StyleSheet.create({
     fontSize: 14,
     marginLeft: 6,
   },
+  // estilos específicos para los botones de tipo de tarea
+  typeOptionBtn: {
+    flex: 1,
+    paddingVertical: Spacing.small,
+    borderRadius: 10,
+    borderWidth: 0.5,
+    borderColor: Colors.text,
+    alignItems: "center",
+    justifyContent: "center",
+    marginRight: Spacing.small,
+  },
+  typeOptionText: {
+    color: Colors.text,
+    fontSize: 14,
+    fontWeight: "600",
+  },
   // estilos de los chips
   tagInputRow: {
     flexDirection: "row",

--- a/src/theme.js
+++ b/src/theme.js
@@ -3,7 +3,9 @@ export const Colors = {
   background: "#0e0a1e", // Fondo oscuro profundo
   surface: "#1b1231", // Superficie ligeramente más clara
   primary: "#7e57c2", // Púrpura místico
+  primaryLight: "#b39ddb", // Versión aclarada para estados activos
   secondary: "#4dd0e1", // Turquesa etéreo
+  secondaryLight: "#80deea", // Variante clara para estados activos
   accent: "#ffca28", // Dorado suave para acentos
   danger: "#ef5350", // Rojo armónico
   text: "#FFFFFF",


### PR DESCRIPTION
## Summary
- add light color variants to theme
- restyle task type buttons to fill modal width and rename "Única" to "Tarea"

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897db69dc0c8327af44c4694aca14b7