### PR TITLE
feat: add subtasks support for tasks

### DIFF
--- a/src/components/SwipeableTaskItem/SwipeableTaskItem.js
+++ b/src/components/SwipeableTaskItem/SwipeableTaskItem.js
@@ -1,6 +1,6 @@
 // src/components/SwipeableTaskItem/SwipeableTaskItem.js
 
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import {
   Animated,
   View,
@@ -97,6 +97,7 @@ export default function SwipeableTaskItem({
   // Información del elemento (icono y color)
   // se usa una función para evitar lógica compleja en el render
   const elementInfo = getElementColor(task.element);
+  const [showSubtasks, setShowSubtasks] = useState(false);
 
   // Estilos de acción al deslizar
   return (
@@ -170,8 +171,6 @@ export default function SwipeableTaskItem({
           style={styles.contentRow}
           onPress={() => onEditTask(task)}
         >
-          {/* textos */}
-
           <View style={styles.textContainer}>
             <Text
               style={[styles.title, task.completed && styles.textCompleted]}
@@ -183,6 +182,50 @@ export default function SwipeableTaskItem({
             </Text>
           </View>
         </TouchableOpacity>
+
+        {task.subtasks?.length > 0 && (
+          <>
+            <TouchableOpacity
+              style={styles.subtaskToggle}
+              onPress={() => setShowSubtasks(!showSubtasks)}
+            >
+              <FontAwesome5
+                name={showSubtasks ? "chevron-up" : "chevron-down"}
+                size={12}
+                color={Colors.textMuted}
+              />
+              <Text style={styles.subtaskToggleText}>Subtareas</Text>
+            </TouchableOpacity>
+            {showSubtasks && (
+              <View style={styles.subtaskList}>
+                {task.subtasks.map((st) => (
+                  <View key={st.id} style={styles.subtaskItem}>
+                    <TouchableOpacity
+                      style={styles.checkbox}
+                      onPress={() => onToggleSubtask(task.id, st.id)}
+                    >
+                      {st.completed && (
+                        <FontAwesome5
+                          name="check"
+                          size={10}
+                          color={Colors.surface}
+                        />
+                      )}
+                    </TouchableOpacity>
+                    <Text
+                      style={[
+                        styles.subtaskText,
+                        st.completed && styles.subtaskTextCompleted,
+                      ]}
+                    >
+                      {st.text}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            )}
+          </>
+        )}
 
         {/* ——— Badges de Elemento y Dificultad ——— */}
         <View style={styles.badgeRow}>
@@ -242,36 +285,6 @@ export default function SwipeableTaskItem({
             {task.tags.map((tag) => (
               <View key={tag} style={styles.tagChip}>
                 <Text style={styles.tagText}>{tag}</Text>
-              </View>
-            ))}
-          </View>
-        )}
-
-        {/* Subtareas (si existen) */}
-        {task.subtasks?.length > 0 && (
-          <View style={styles.subtaskList}>
-            {task.subtasks.map((st) => (
-              <View key={st.id} style={styles.subtaskItem}>
-                <TouchableOpacity
-                  style={styles.checkbox}
-                  onPress={() => onToggleSubtask(task.id, st.id)}
-                >
-                  {st.completed && (
-                    <FontAwesome5
-                      name="check"
-                      size={10}
-                      color={Colors.surface}
-                    />
-                  )}
-                </TouchableOpacity>
-                <Text
-                  style={[
-                    styles.subtaskText,
-                    st.completed && styles.subtaskTextCompleted,
-                  ]}
-                >
-                  {st.text}
-                </Text>
               </View>
             ))}
           </View>

--- a/src/components/SwipeableTaskItem/SwipeableTaskItem.styles.js
+++ b/src/components/SwipeableTaskItem/SwipeableTaskItem.styles.js
@@ -75,6 +75,16 @@ export default StyleSheet.create({
     color: Colors.textMuted,
     textDecorationLine: "line-through",
   },
+  subtaskToggle: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginTop: Spacing.tiny,
+  },
+  subtaskToggleText: {
+    color: Colors.textMuted,
+    marginLeft: Spacing.tiny,
+    fontSize: 12,
+  },
   subtaskList: {
     marginTop: Spacing.small,
     paddingLeft: Spacing.small,

--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -151,6 +151,10 @@ export default function TasksScreen() {
       priority: "medium",
       tags: ["personal"],
       difficulty: "hard",
+      subtasks: [
+        { id: 1, text: "Revisar opciones", completed: false },
+        { id: 2, text: "Hacer pedido", completed: false },
+      ],
     },
     {
       id: 2,
@@ -185,6 +189,8 @@ export default function TasksScreen() {
   // ➕ Estados para etiquetas en modal
   const [newTagInput, setNewTagInput] = useState("");
   const [newTags, setNewTags] = useState([]);
+  const [newSubtaskInput, setNewSubtaskInput] = useState("");
+  const [newSubtasks, setNewSubtasks] = useState([]);
   // Opciones del tipo de tarea
   const typeOptions = [
     { key: "single", label: "Tarea", activeColor: Colors.primaryLight },
@@ -216,6 +222,11 @@ export default function TasksScreen() {
       priority: newPriority,
       tags: newTags.length > 0 ? newTags : [], // si hay etiquetas, las usamos
       difficulty: newDifficulty, // dificultad por defecto
+      subtasks: newSubtasks.map((text, index) => ({
+        id: index + 1,
+        text,
+        completed: false,
+      })),
     };
     // Añadimos la nueva tarea al estado
     setTasks((prev) => [newTask, ...prev]);
@@ -226,6 +237,8 @@ export default function TasksScreen() {
     setNewType("single");
     setNewElement("all");
     setNewPriority("easy");
+    setNewSubtaskInput("");
+    setNewSubtasks([]);
     setShowAddModal(false);
   };
 
@@ -471,6 +484,38 @@ export default function TasksScreen() {
 
                   {elementInfo[newElement].purpose}
                 </Text>
+              </View>
+            )}
+
+            {/* Subtareas */}
+            <Text style={modalStyles.label}>Subtareas</Text>
+            <View style={modalStyles.subtaskInputRow}>
+              <TextInput
+                style={modalStyles.subtaskInput}
+                placeholder="Nueva subtarea"
+                placeholderTextColor={Colors.textMuted}
+                value={newSubtaskInput}
+                onChangeText={setNewSubtaskInput}
+              />
+              <TouchableOpacity
+                style={modalStyles.addSubtaskButton}
+                onPress={() => {
+                  const st = newSubtaskInput.trim();
+                  if (!st) return;
+                  setNewSubtasks((prev) => [...prev, st]);
+                  setNewSubtaskInput("");
+                }}
+              >
+                <FontAwesome5 name="plus" size={16} color={Colors.background} />
+              </TouchableOpacity>
+            </View>
+            {newSubtasks.length > 0 && (
+              <View style={modalStyles.subtaskList}>
+                {newSubtasks.map((st, idx) => (
+                  <View key={idx} style={modalStyles.subtaskItem}>
+                    <Text style={modalStyles.subtaskText}>{st}</Text>
+                  </View>
+                ))}
               </View>
             )}
 

--- a/src/screens/TasksScreen.styles.js
+++ b/src/screens/TasksScreen.styles.js
@@ -222,4 +222,38 @@ export const modalStyles = StyleSheet.create({
     color: Colors.text,
     fontSize: 12,
   },
+  subtaskInputRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: Spacing.base,
+  },
+  subtaskInput: {
+    flex: 1,
+    backgroundColor: Colors.background,
+    color: Colors.text,
+    borderRadius: 8,
+    paddingHorizontal: Spacing.small,
+    paddingVertical: Spacing.small,
+    fontSize: 14,
+  },
+  addSubtaskButton: {
+    marginLeft: Spacing.small,
+    backgroundColor: Colors.primary,
+    padding: Spacing.small,
+    borderRadius: 8,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  subtaskList: {
+    marginBottom: Spacing.base,
+  },
+  subtaskItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: Spacing.tiny,
+  },
+  subtaskText: {
+    color: Colors.text,
+    fontSize: 13,
+  },
 });


### PR DESCRIPTION
## Summary
- allow creating subtasks when adding a task
- show subtasks in each task card with an expandable checklist

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6898ba087b94832785040bc5428528ff