### PR TITLE
Add apply and reset controls to TaskFilters

### DIFF
--- a/src/components/TaskFilters.js
+++ b/src/components/TaskFilters.js
@@ -1,0 +1,93 @@
+import React, { useState } from "react";
+import { View, TouchableOpacity, Text, StyleSheet } from "react-native";
+import FilterBar from "./FilterBar/FilterBar";
+import AdvancedFilters from "./AdvancedFilters/AdvancedFilters";
+import { Colors, Spacing } from "../theme";
+
+export default function TaskFilters({
+  filters = [],
+  elementOptions = [],
+  priorityOptions = [],
+  difficultyOptions = [],
+  tags = [],
+  onSelect,
+}) {
+  const [active, setActive] = useState("all");
+  const [elementFilter, setElementFilter] = useState("all");
+  const [priorityFilter, setPriorityFilter] = useState("all");
+  const [difficultyFilter, setDifficultyFilter] = useState("all");
+  const [tagFilter, setTagFilter] = useState("all");
+
+  const onApply = () => {
+    if (onSelect) {
+      onSelect({
+        active,
+        elementFilter,
+        priorityFilter,
+        difficultyFilter,
+        tagFilter,
+      });
+    }
+  };
+
+  const onReset = () => {
+    setActive("all");
+    setElementFilter("all");
+    setPriorityFilter("all");
+    setDifficultyFilter("all");
+    setTagFilter("all");
+  };
+
+  return (
+    <View>
+      <FilterBar filters={filters} active={active} onSelect={setActive} />
+      <AdvancedFilters
+        elementOptions={elementOptions}
+        elementFilter={elementFilter}
+        setElementFilter={setElementFilter}
+        priorityOptions={priorityOptions}
+        priorityFilter={priorityFilter}
+        setPriorityFilter={setPriorityFilter}
+        difficultyOptions={difficultyOptions}
+        difficultyFilter={difficultyFilter}
+        setDifficultyFilter={setDifficultyFilter}
+        tags={tags}
+        tagFilter={tagFilter}
+        setTagFilter={setTagFilter}
+      />
+      <View style={styles.buttons}>
+        <TouchableOpacity style={[styles.button, styles.apply]} onPress={onApply}>
+          <Text style={styles.buttonText}>Aplicar</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={[styles.button, styles.reset]} onPress={onReset}>
+          <Text style={styles.buttonText}>Resetear</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  buttons: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginTop: Spacing.base,
+  },
+  button: {
+    flex: 1,
+    padding: Spacing.small,
+    borderRadius: 8,
+    alignItems: "center",
+    marginHorizontal: Spacing.tiny,
+  },
+  apply: {
+    backgroundColor: Colors.primary,
+  },
+  reset: {
+    backgroundColor: Colors.danger,
+  },
+  buttonText: {
+    color: Colors.background,
+    fontWeight: "600",
+  },
+});


### PR DESCRIPTION
## Summary
- add TaskFilters component with internal filter state management
- provide Apply and Reset buttons to trigger selection logic or clear filters

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898c29b4a888327836c292359fb6bde