### PR TITLE
Improve tag filter spacing and input UX

### DIFF
--- a/src/components/AdvancedFilters/AdvancedFilters.js
+++ b/src/components/AdvancedFilters/AdvancedFilters.js
@@ -1,7 +1,13 @@
 // src/components/AdvancedFilters/AdvancedFilters.js
 
 import React, { useState, useEffect } from "react";
-import { View, Text, TouchableOpacity, ScrollView, TextInput } from "react-native";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  ScrollView,
+  TextInput,
+} from "react-native";
 import { FontAwesome5 } from "@expo/vector-icons";
 import styles from "./AdvancedFilters.styles";
 import { Colors } from "../../theme";
@@ -69,6 +75,7 @@ export default function AdvancedFilters({
   tagBtnStyle,
 }) {
   const [tagSearch, setTagSearch] = useState("");
+  const [tagSearchFocused, setTagSearchFocused] = useState(false);
   const [debouncedTagSearch, setDebouncedTagSearch] = useState(tagSearch);
 
   useEffect(() => {
@@ -104,13 +111,30 @@ export default function AdvancedFilters({
         styles.difficultyBtn,
         difficultyBtnStyle
       )}
-      <TextInput
-        style={styles.tagSearchInput}
-        placeholder="Buscar etiqueta"
-        placeholderTextColor={Colors.text}
-        value={tagSearch}
-        onChangeText={setTagSearch}
-      />
+      <View
+        style={[
+          styles.tagSearchContainer,
+          tagSearchFocused && styles.tagSearchContainerFocused,
+        ]}
+      >
+        <TextInput
+          style={styles.tagSearchInput}
+          placeholder="Buscar etiqueta"
+          placeholderTextColor={Colors.text}
+          value={tagSearch}
+          onChangeText={setTagSearch}
+          onFocus={() => setTagSearchFocused(true)}
+          onBlur={() => setTagSearchFocused(false)}
+        />
+        {tagSearch.length > 0 && (
+          <TouchableOpacity
+            onPress={() => setTagSearch("")}
+            style={styles.clearBtn}
+          >
+            <FontAwesome5 name="times" size={14} color={Colors.text} />
+          </TouchableOpacity>
+        )}
+      </View>
       {renderRow(
         filteredTags.map((tag) => ({ key: tag, label: tag, color: Colors.accent })),
         tagFilter,

--- a/src/components/AdvancedFilters/AdvancedFilters.styles.js
+++ b/src/components/AdvancedFilters/AdvancedFilters.styles.js
@@ -31,7 +31,7 @@ export default StyleSheet.create({
   },
   row: {
     flexDirection: "row",
-    marginBottom: Spacing.base,
+    marginBottom: Spacing.large,
   },
   elementBtn: {
     ...baseBtn,
@@ -44,15 +44,30 @@ export default StyleSheet.create({
   },
   tagBtn: {
     ...baseBtn,
+    marginRight: Spacing.base,
+    marginBottom: Spacing.small,
   },
-  tagSearchInput: {
+  tagSearchContainer: {
+    flexDirection: "row",
+    alignItems: "center",
     borderWidth: 0.5,
     borderColor: Colors.text,
     borderRadius: 8,
     padding: Spacing.tiny,
     paddingHorizontal: Spacing.small,
-    marginBottom: Spacing.base,
+    marginBottom: Spacing.large,
+    backgroundColor: Colors.surface,
+  },
+  tagSearchContainerFocused: {
+    borderColor: Colors.accent,
+  },
+  tagSearchInput: {
+    flex: 1,
     color: Colors.text,
+  },
+  clearBtn: {
+    marginLeft: Spacing.small,
+    padding: Spacing.tiny,
   },
   text: {
     color: Colors.text,


### PR DESCRIPTION
## Summary
- Expand spacing for filter rows and tag chips
- Add focus styles and clear button to tag search input

## Testing
- `npm test` *(fails: Missing script "test")*
- `node - <<'NODE'\nconst counts = [0, 5, 20];\nconst search = 'a';\nfor (const count of counts) {\n  const tags = Array.from({length: count}, (_, i) => `tag${i}`);\n  const filtered = tags.filter(t => t.toLowerCase().includes(search));\n  console.log(`tags:${count} filtered:${filtered.length}`);\n}\nNODE`


------
https://chatgpt.com/codex/tasks/task_e_6898d00893dc832789fa0af53b3beebf