### PR TITLE
Refactor filter modal header and styles

### DIFF
--- a/src/components/TaskFilters/TaskFilters.js
+++ b/src/components/TaskFilters/TaskFilters.js
@@ -68,9 +68,16 @@ export default function TaskFilters({
   tags = [],
   tagFilter,
   setTagFilter,
+  onClose,
 }) {
   return (
     <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Filtros</Text>
+        <TouchableOpacity onPress={onClose} style={styles.headerClose}>
+          <FontAwesome name="times" style={styles.headerCloseIcon} />
+        </TouchableOpacity>
+      </View>
       <View style={styles.section}>
         <Text style={styles.sectionTitle}>Estado</Text>
         {renderRow(

--- a/src/components/TaskFilters/TaskFilters.styles.js
+++ b/src/components/TaskFilters/TaskFilters.styles.js
@@ -20,6 +20,26 @@ export default StyleSheet.create({
     borderTopRightRadius: 16,
     padding: Spacing.base,
   },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingBottom: Spacing.small,
+    marginBottom: Spacing.base,
+  },
+  headerTitle: {
+    color: Colors.text,
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  headerClose: {
+    padding: Spacing.tiny,
+    borderRadius: 8,
+  },
+  headerCloseIcon: {
+    fontSize: 20,
+    color: Colors.text,
+  },
   section: {
     marginBottom: Spacing.base,
   },

--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -365,40 +365,27 @@ export default function TasksScreen() {
         transparent={true}
         onRequestClose={() => setFiltersVisible(false)}
       >
-        <View
-          style={{
-            flex: 1,
-            justifyContent: "flex-end",
-            backgroundColor: "rgba(0,0,0,0.5)",
-          }}
-        >
-          <TaskFilters
-            filters={mainFilters}
-            active={activeFilter}
-            onSelect={setActiveFilter}
-            elementOptions={elementOptions}
-            elementFilter={elementFilter}
-            setElementFilter={setElementFilter}
-            priorityOptions={priorityOptions}
-            priorityFilter={priorityFilter}
-            setPriorityFilter={setPriorityFilter}
-            difficultyOptions={difficultyOptions}
-            difficultyFilter={difficultyFilter}
-            setDifficultyFilter={setDifficultyFilter}
-            tags={uniqueTags}
-            tagFilter={tagFilter}
-            setTagFilter={setTagFilter}
-          />
-          <TouchableOpacity
-            onPress={() => setFiltersVisible(false)}
-            style={{
-              backgroundColor: Colors.surface,
-              padding: Spacing.small,
-              alignItems: "center",
-            }}
-          >
-            <Text style={{ color: Colors.text }}>Cerrar</Text>
-          </TouchableOpacity>
+        <View style={styles.filterModalBackground}>
+          <View style={styles.filterModalContainer}>
+            <TaskFilters
+              filters={mainFilters}
+              active={activeFilter}
+              onSelect={setActiveFilter}
+              elementOptions={elementOptions}
+              elementFilter={elementFilter}
+              setElementFilter={setElementFilter}
+              priorityOptions={priorityOptions}
+              priorityFilter={priorityFilter}
+              setPriorityFilter={setPriorityFilter}
+              difficultyOptions={difficultyOptions}
+              difficultyFilter={difficultyFilter}
+              setDifficultyFilter={setDifficultyFilter}
+              tags={uniqueTags}
+              tagFilter={tagFilter}
+              setTagFilter={setTagFilter}
+              onClose={() => setFiltersVisible(false)}
+            />
+          </View>
         </View>
       </Modal>
 

--- a/src/screens/TasksScreen.styles.js
+++ b/src/screens/TasksScreen.styles.js
@@ -16,6 +16,14 @@ export default StyleSheet.create({
   list: {
     marginTop: Spacing.small,
   },
+  filterModalBackground: {
+    flex: 1,
+    justifyContent: "flex-end",
+    backgroundColor: "rgba(0,0,0,0.5)",
+  },
+  filterModalContainer: {
+    backgroundColor: Colors.surface,
+  },
 });
 
 export const modalStyles = StyleSheet.create({


### PR DESCRIPTION
## Summary
- move filter modal overlay styling into screen stylesheet
- add modal header with title and close icon to task filters
- centralize task filter header styles and cleanup inline styles

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898d009f8e08327b36d9af29e525b40