### PR TITLE
Refine advanced filter modal UI

### DIFF
--- a/src/components/AdvancedFilters/AdvancedFilters.js
+++ b/src/components/AdvancedFilters/AdvancedFilters.js
@@ -10,9 +10,93 @@ import {
 } from "react-native";
 import { FontAwesome5 } from "@expo/vector-icons";
 import styles from "./AdvancedFilters.styles";
-import { Colors } from "../../theme";
+import { Colors, Spacing } from "../../theme";
 
-function renderRow(options, activeKey, setActive, baseStyle, overrideStyle) {
+function renderElementGrid(options, activeKey, setActive, overrideStyle) {
+  return (
+    <View style={styles.elementGrid}>
+      {options.map((opt) => {
+        const isActive = activeKey === opt.key;
+        return (
+          <TouchableOpacity
+            key={opt.key}
+            style={[
+              styles.elementGridBtn,
+              overrideStyle,
+              isActive && {
+                backgroundColor: opt.color,
+                borderColor: opt.color,
+              },
+            ]}
+            onPress={() => setActive(opt.key)}
+          >
+            {opt.icon && (
+              <FontAwesome5
+                name={opt.icon}
+                size={18}
+                color={isActive ? Colors.background : opt.color}
+              />
+            )}
+            <Text
+              style={[
+                styles.text,
+                isActive && { color: Colors.background },
+              ]}
+            >
+              {opt.label}
+            </Text>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+}
+
+function renderFullRow(options, activeKey, setActive, baseStyle, overrideStyle) {
+  return (
+    <View style={styles.row}>
+      {options.map((opt, index) => {
+        const isActive = activeKey === opt.key;
+        return (
+          <TouchableOpacity
+            key={opt.key}
+            style={[
+              baseStyle,
+              overrideStyle,
+              {
+                flex: 1,
+                marginRight: index === options.length - 1 ? 0 : Spacing.small,
+              },
+              isActive && {
+                backgroundColor: opt.color,
+                borderColor: opt.color,
+              },
+            ]}
+            onPress={() => setActive(opt.key)}
+          >
+            {opt.icon && (
+              <FontAwesome5
+                name={opt.icon}
+                size={14}
+                color={isActive ? Colors.background : opt.color}
+              />
+            )}
+            <Text
+              style={[
+                styles.text,
+                isActive && { color: Colors.background },
+              ]}
+            >
+              {opt.label}
+            </Text>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+}
+
+function renderTagRow(options, activeKey, setActive, baseStyle, overrideStyle) {
   return (
     <ScrollView
       horizontal
@@ -34,16 +118,9 @@ function renderRow(options, activeKey, setActive, baseStyle, overrideStyle) {
             ]}
             onPress={() => setActive(opt.key)}
           >
-            {opt.icon && (
-              <FontAwesome5
-                name={opt.icon}
-                size={14}
-                color={isActive ? Colors.background : opt.color}
-              />
-            )}
             <Text
               style={[
-                styles.text,
+                styles.tagText,
                 isActive && { color: Colors.background },
               ]}
             >
@@ -90,21 +167,20 @@ export default function AdvancedFilters({
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Filtros avanzados</Text>
-      {renderRow(
+      {renderElementGrid(
         elementOptions,
         elementFilter,
         setElementFilter,
-        styles.elementBtn,
         elementBtnStyle
       )}
-      {renderRow(
+      {renderFullRow(
         priorityOptions,
         priorityFilter,
         setPriorityFilter,
         styles.priorityBtn,
         priorityBtnStyle
       )}
-      {renderRow(
+      {renderFullRow(
         difficultyOptions,
         difficultyFilter,
         setDifficultyFilter,
@@ -135,8 +211,12 @@ export default function AdvancedFilters({
           </TouchableOpacity>
         )}
       </View>
-      {renderRow(
-        filteredTags.map((tag) => ({ key: tag, label: tag, color: Colors.accent })),
+      {renderTagRow(
+        filteredTags.map((tag) => ({
+          key: tag,
+          label: tag,
+          color: Colors.accent,
+        })),
         tagFilter,
         setTagFilter,
         styles.tagBtn,
@@ -145,3 +225,4 @@ export default function AdvancedFilters({
     </View>
   );
 }
+

--- a/src/components/AdvancedFilters/AdvancedFilters.styles.js
+++ b/src/components/AdvancedFilters/AdvancedFilters.styles.js
@@ -33,8 +33,18 @@ export default StyleSheet.create({
     flexDirection: "row",
     marginBottom: Spacing.large,
   },
-  elementBtn: {
+  elementGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "space-between",
+    marginBottom: Spacing.large,
+  },
+  elementGridBtn: {
     ...baseBtn,
+    width: "48%",
+    justifyContent: "center",
+    marginRight: 0,
+    marginBottom: Spacing.small,
   },
   priorityBtn: {
     ...baseBtn,
@@ -44,6 +54,8 @@ export default StyleSheet.create({
   },
   tagBtn: {
     ...baseBtn,
+    paddingVertical: Spacing.tiny,
+    paddingHorizontal: Spacing.tiny,
     marginRight: Spacing.base,
     marginBottom: Spacing.small,
   },
@@ -72,6 +84,11 @@ export default StyleSheet.create({
   text: {
     color: Colors.text,
     fontSize: 14,
+    marginLeft: Spacing.small,
+  },
+  tagText: {
+    color: Colors.text,
+    fontSize: 12,
     marginLeft: Spacing.small,
   },
 });

--- a/src/components/TaskFilters.js
+++ b/src/components/TaskFilters.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { View, TouchableOpacity, Text, StyleSheet } from "react-native";
+import { FontAwesome5 } from "@expo/vector-icons";
 import FilterBar from "./FilterBar/FilterBar";
 import AdvancedFilters from "./AdvancedFilters/AdvancedFilters";
 import { Colors, Spacing } from "../theme";
@@ -11,6 +12,7 @@ export default function TaskFilters({
   difficultyOptions = [],
   tags = [],
   onSelect,
+  onClose,
 }) {
   const [active, setActive] = useState("all");
   const [elementFilter, setElementFilter] = useState("all");
@@ -40,6 +42,11 @@ export default function TaskFilters({
 
   return (
     <View>
+      {onClose && (
+        <TouchableOpacity style={styles.closeBtn} onPress={onClose}>
+          <FontAwesome5 name="times" size={16} color={Colors.text} />
+        </TouchableOpacity>
+      )}
       <FilterBar filters={filters} active={active} onSelect={setActive} />
       <AdvancedFilters
         elementOptions={elementOptions}
@@ -68,6 +75,10 @@ export default function TaskFilters({
 }
 
 const styles = StyleSheet.create({
+  closeBtn: {
+    alignSelf: "flex-end",
+    padding: Spacing.tiny,
+  },
   buttons: {
     flexDirection: "row",
     justifyContent: "space-between",

--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -46,21 +46,21 @@ const statusFilters = [
 const priorityOptions = [
   {
     key: "easy",
-    label: "Fácil",
+    label: "Baja",
     color: Colors.secondary,
     xp: 10,
     mana: 5,
   },
   {
     key: "medium",
-    label: "Medio",
+    label: "Media",
     color: Colors.accent,
     xp: 25,
     mana: 12,
   },
   {
     key: "hard",
-    label: "Difícil",
+    label: "Urgente",
     color: Colors.danger,
     xp: 50,
     mana: 25,


### PR DESCRIPTION
## Summary
- Rename priority labels to Baja, Media and Urgente
- Rework AdvancedFilters layout with 2x2 element grid, full-width priority/difficulty buttons, and compact tags
- Add close button to TaskFilters for dismissing the modal

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6898d2f5c8f0832794ab9311ad45a7d3