### PR TITLE
feat: add footer bottom navigation

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,14 +1,49 @@
 // App.js
 
-import React from "react";
-import { SafeAreaView, StyleSheet } from "react-native";
+import React, { useState } from "react";
+import { SafeAreaView, StyleSheet, View, Text } from "react-native";
 import { Colors } from "./src/theme";
 import TasksScreen from "./src/screens/TasksScreen";
+import Footer from "./src/components/Footer";
 
 export default function App() {
+  const [activeScreen, setActiveScreen] = useState("tasks");
+
+  const handleNavigate = (screen) => {
+    setActiveScreen(screen);
+  };
+
+  const renderScreen = () => {
+    switch (activeScreen) {
+      case "tasks":
+        return <TasksScreen />;
+      case "plant":
+        return (
+          <View style={styles.placeholder}>
+            <Text style={styles.placeholderText}>Planta</Text>
+          </View>
+        );
+      case "stats":
+        return (
+          <View style={styles.placeholder}>
+            <Text style={styles.placeholderText}>Estadísticas</Text>
+          </View>
+        );
+      case "profile":
+        return (
+          <View style={styles.placeholder}>
+            <Text style={styles.placeholderText}>Perfil</Text>
+          </View>
+        );
+      default:
+        return null;
+    }
+  };
+
   return (
     <SafeAreaView style={styles.container}>
-      <TasksScreen />
+      {renderScreen()}
+      <Footer activeScreen={activeScreen} onNavigate={handleNavigate} />
     </SafeAreaView>
   );
 }
@@ -17,5 +52,14 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: Colors.background, // <-- aquí usamos tu token de tema
+  },
+  placeholder: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  placeholderText: {
+    color: Colors.text,
+    fontSize: 16,
   },
 });

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,0 +1,42 @@
+import React from "react";
+import { View, Text, TouchableOpacity } from "react-native";
+import { FontAwesome5 } from "@expo/vector-icons";
+import styles from "./Footer.styles";
+import { Colors } from "../theme";
+
+export default function Footer({ activeScreen, onNavigate }) {
+  const buttons = [
+    { key: "tasks", label: "Tareas", icon: "list-ul" },
+    { key: "plant", label: "Planta", icon: "leaf" },
+    { key: "stats", label: "Estadísticas", icon: "chart-bar" },
+    { key: "profile", label: "Perfil", icon: "user-circle" },
+  ];
+
+  return (
+    <View style={styles.container}>
+      {buttons.map((btn) => {
+        const isActive = activeScreen === btn.key;
+        return (
+          <TouchableOpacity
+            key={btn.key}
+            style={styles.button}
+            onPress={() => onNavigate(btn.key)}
+          >
+            <View
+              style={
+                isActive ? styles.activeIconWrapper : styles.iconWrapper
+              }
+            >
+              <FontAwesome5
+                name={btn.icon}
+                size={isActive ? 24 : 20}
+                color={isActive ? Colors.text : Colors.textMuted}
+              />
+            </View>
+            {isActive && <Text style={styles.label}>{btn.label}</Text>}
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+}

--- a/src/components/Footer.styles.js
+++ b/src/components/Footer.styles.js
@@ -1,0 +1,41 @@
+import { StyleSheet } from "react-native";
+import { Colors, Spacing } from "../theme";
+
+export default StyleSheet.create({
+  container: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    flexDirection: "row",
+    justifyContent: "space-around",
+    alignItems: "center",
+    backgroundColor: "rgba(255,255,255,0.1)",
+    paddingVertical: Spacing.small,
+    borderTopWidth: 1,
+    borderTopColor: "rgba(255,255,255,0.2)",
+    shadowColor: Colors.shadow,
+    shadowOffset: { width: 0, height: -2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+  },
+  button: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  iconWrapper: {
+    padding: Spacing.small,
+    borderRadius: 20,
+  },
+  activeIconWrapper: {
+    padding: Spacing.small,
+    borderRadius: 20,
+    backgroundColor: Colors.accent,
+  },
+  label: {
+    marginTop: Spacing.tiny,
+    fontSize: 12,
+    color: Colors.text,
+  },
+});


### PR DESCRIPTION
## Summary
- add reusable footer component with FontAwesome icons and active state
- style footer with glass-like background and active button highlight
- wire footer navigation into App with placeholders for other screens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898e6ff8e9083278579ffa01d227470