### PR TITLE
Fix advanced filter modal overlay centering

### DIFF
--- a/src/screens/TasksScreen.styles.js
+++ b/src/screens/TasksScreen.styles.js
@@ -16,6 +16,19 @@ export default StyleSheet.create({
   list: {
     marginTop: Spacing.small,
   },
+  filterModalBackground: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  filterModalContainer: {
+    width: "90%",
+    backgroundColor: Colors.surface,
+    borderRadius: 12,
+    padding: Spacing.base,
+    maxHeight: "90%",
+  },
 });
 
 export const modalStyles = StyleSheet.create({


### PR DESCRIPTION
## Summary
- restore background overlay and centering for advanced filter modal

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898f06f53a88327913a5b6b652bf8ae