### PR TITLE
feat: add fantasy color palette

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -5,6 +5,9 @@ export const Colors = {
   primary: "#7e57c2", // Púrpura místico
   primaryLight: "#b39ddb", // Versión aclarada para estados activos
   secondary: "#1cd47bff", // Turquesa etéreo
+  primaryFantasy: '#B542F6',
+  secondaryFantasy: '#F8329D',
+  tertiaryFantasy: '#FFD700',
 
   secondaryLight: "#80deea", // Variante clara para estados activos
   accent: "#ffca28", // Dorado suave para acentos


### PR DESCRIPTION
## Summary
- add fantasy themed colors to theme configuration

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6898f44d0b948327896a1f9c001a7c09