### PR TITLE
Add subtasks hint label

### DIFF
--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -514,7 +514,9 @@ export default function TasksScreen() {
             )}
 
             {/* Subtareas */}
-            <Text style={modalStyles.label}>Subtareas</Text>
+            <Text style={modalStyles.label}>
+              Subtareas <Text style={modalStyles.subtaskHint}>(agrega y toca para marcar)</Text>
+            </Text>
             <View style={modalStyles.subtaskInputRow}>
               <TextInput
                 style={modalStyles.subtaskInput}

--- a/src/screens/TasksScreen.styles.js
+++ b/src/screens/TasksScreen.styles.js
@@ -75,6 +75,10 @@ export const modalStyles = StyleSheet.create({
     marginTop: Spacing.base,
     marginBottom: Spacing.small,
   },
+  subtaskHint: {
+    color: Colors.textMuted,
+    fontSize: 12,
+  },
   row: {
     flexDirection: "row",
     marginBottom: Spacing.base,


### PR DESCRIPTION
## Summary
- add guidance hint to subtasks section
- style hint text with smaller muted font

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Missing script: "lint")

------
https://chatgpt.com/codex/tasks/task_e_6898f49679d0832791d79ce44b2602c9