### PR TITLE
Enhance AddTaskButton styles

### DIFF
--- a/src/components/AddTaskButton/AddTaskButton.styles.js
+++ b/src/components/AddTaskButton/AddTaskButton.styles.js
@@ -11,7 +11,6 @@ export default StyleSheet.create({
     width: 60,
     height: 60,
     borderRadius: 30,
-    backgroundColor: Colors.buttonBg,
     justifyContent: "center",
     alignItems: "center",
     shadowColor: Colors.shadow,
@@ -20,5 +19,11 @@ export default StyleSheet.create({
     shadowOpacity: 0.3,
     shadowRadius: 6,
     elevation: 8,
+  },
+  gradient: { width: "100%", height: "100%", borderRadius: 30 },
+  fabShadowPressed: {
+    shadowOpacity: 0.5,
+    shadowRadius: 10,
+    elevation: 12,
   },
 });


### PR DESCRIPTION
## Summary
- remove static background color from AddTaskButton FAB
- add gradient wrapper and pressed shadow style

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898f4f256b88327834e20f7b5a9b422