### PR TITLE
feat: add gradient and pressed state to FAB

### DIFF
--- a/src/components/AddTaskButton/AddTaskButton.js
+++ b/src/components/AddTaskButton/AddTaskButton.js
@@ -1,15 +1,31 @@
 // src/components/AddTaskButton/AddTaskButton.js
 
-import React from "react";
+import React, { useState } from "react";
 import { TouchableOpacity } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
 import { FontAwesome } from "@expo/vector-icons";
 import styles from "./AddTaskButton.styles";
 import { Colors } from "../../theme";
 
 export default function AddTaskButton({ onPress }) {
+  const [isPressed, setIsPressed] = useState(false);
   return (
-    <TouchableOpacity style={styles.fab} onPress={onPress}>
-      <FontAwesome name="plus" size={24} color={Colors.background} />
+    <TouchableOpacity
+      style={[styles.fab, isPressed && styles.fabShadowPressed]}
+      onPress={onPress}
+      onPressIn={() => setIsPressed(true)}
+      onPressOut={() => setIsPressed(false)}
+    >
+      <LinearGradient
+        colors={[
+          Colors.primaryFantasy,
+          Colors.secondaryFantasy,
+          Colors.tertiaryFantasy,
+        ]}
+        style={styles.gradient}
+      >
+        <FontAwesome name="plus" size={24} color={Colors.background} />
+      </LinearGradient>
     </TouchableOpacity>
   );
 }


### PR DESCRIPTION
## Summary
- add pressed state handling to AddTaskButton
- render button icon over gradient background

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898f5d924008327acfbd48bea2582d5