### PR TITLE
style: improve advanced filters UI

### DIFF
--- a/src/components/AdvancedFilters/AdvancedFilters.js
+++ b/src/components/AdvancedFilters/AdvancedFilters.js
@@ -157,38 +157,42 @@ export default function AdvancedFilters({
     return () => clearTimeout(handler);
   }, [tagSearch]);
 
-  const filteredTags = tags.filter((tag) =>
-    tag.toLowerCase().includes(debouncedTagSearch.toLowerCase())
-  );
+    const filteredTags = tags.filter((tag) =>
+      tag.toLowerCase().includes(debouncedTagSearch.toLowerCase())
+    );
 
-  return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Filtros avanzados</Text>
-      {renderElementGrid(
-        elementOptions,
-        elementFilter,
-        setElementFilter,
-        elementBtnStyle
-      )}
-      {renderFullRow(
-        priorityOptions,
-        priorityFilter,
-        setPriorityFilter,
-        styles.priorityBtn,
-        priorityBtnStyle
-      )}
-      {renderFullRow(
-        difficultyOptions,
-        difficultyFilter,
-        setDifficultyFilter,
-        styles.difficultyBtn,
-        difficultyBtnStyle
-      )}
-      <View
-        style={[
-          styles.tagSearchContainer,
-          tagSearchFocused && styles.tagSearchContainerFocused,
-        ]}
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>Filtros avanzados</Text>
+        <Text style={styles.sectionTitle}>Elemento</Text>
+        {renderElementGrid(
+          elementOptions,
+          elementFilter,
+          setElementFilter,
+          elementBtnStyle
+        )}
+        <Text style={styles.sectionTitle}>Prioridad</Text>
+        {renderFullRow(
+          priorityOptions,
+          priorityFilter,
+          setPriorityFilter,
+          styles.priorityBtn,
+          priorityBtnStyle
+        )}
+        <Text style={styles.sectionTitle}>Dificultad</Text>
+        {renderFullRow(
+          difficultyOptions,
+          difficultyFilter,
+          setDifficultyFilter,
+          styles.difficultyBtn,
+          difficultyBtnStyle
+        )}
+        <Text style={styles.sectionTitle}>Etiquetas</Text>
+        <View
+          style={[
+            styles.tagSearchContainer,
+            tagSearchFocused && styles.tagSearchContainerFocused,
+          ]}
       >
         <TextInput
           style={styles.tagSearchInput}

--- a/src/components/AdvancedFilters/AdvancedFilters.styles.js
+++ b/src/components/AdvancedFilters/AdvancedFilters.styles.js
@@ -57,6 +57,31 @@ export default StyleSheet.create({
   tagBtn: {
     ...baseBtn,
   },
+  tagText: {
+    color: Colors.text,
+    fontSize: 14,
+  },
+  tagSearchContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: Colors.filterBtnBg,
+    borderRadius: 8,
+    borderWidth: 0.5,
+    borderColor: Colors.text,
+    paddingHorizontal: Spacing.small,
+    marginBottom: Spacing.base,
+  },
+  tagSearchContainerFocused: {
+    borderColor: Colors.accent,
+  },
+  tagSearchInput: {
+    flex: 1,
+    color: Colors.text,
+    paddingVertical: 0,
+  },
+  clearBtn: {
+    marginLeft: Spacing.small,
+  },
   sectionTitle: {
     color: Colors.text,
     fontSize: 14,


### PR DESCRIPTION
## Summary
- improve tag button text contrast in advanced filters
- restore search input styling and section headers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68992aa10b748327be6e21277f542e91