### PR TITLE
style: improve advanced filters UI

### DIFF
--- a/src/components/AdvancedFilters/AdvancedFilters.js
+++ b/src/components/AdvancedFilters/AdvancedFilters.js
@@ -85,7 +85,11 @@ function renderFullRow(
               />
             )}
             <Text
-              style={[styles.text, isActive && { color: Colors.background }]}
+              style={[
+                styles.text,
+                !opt.icon && styles.centerText,
+                isActive && { color: Colors.background },
+              ]}
             >
               {opt.label}
             </Text>
@@ -157,38 +161,41 @@ export default function AdvancedFilters({
     return () => clearTimeout(handler);
   }, [tagSearch]);
 
-  const filteredTags = tags.filter((tag) =>
-    tag.toLowerCase().includes(debouncedTagSearch.toLowerCase())
-  );
+    const filteredTags = tags.filter((tag) =>
+      tag.toLowerCase().includes(debouncedTagSearch.toLowerCase())
+    );
 
-  return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Filtros avanzados</Text>
-      {renderElementGrid(
-        elementOptions,
-        elementFilter,
-        setElementFilter,
-        elementBtnStyle
-      )}
-      {renderFullRow(
-        priorityOptions,
-        priorityFilter,
-        setPriorityFilter,
-        styles.priorityBtn,
-        priorityBtnStyle
-      )}
-      {renderFullRow(
-        difficultyOptions,
-        difficultyFilter,
-        setDifficultyFilter,
-        styles.difficultyBtn,
-        difficultyBtnStyle
-      )}
-      <View
-        style={[
-          styles.tagSearchContainer,
-          tagSearchFocused && styles.tagSearchContainerFocused,
-        ]}
+    return (
+      <View style={styles.container}>
+        <Text style={styles.sectionTitle}>Elemento</Text>
+        {renderElementGrid(
+          elementOptions,
+          elementFilter,
+          setElementFilter,
+          elementBtnStyle
+        )}
+        <Text style={styles.sectionTitle}>Prioridad</Text>
+        {renderFullRow(
+          priorityOptions,
+          priorityFilter,
+          setPriorityFilter,
+          styles.priorityBtn,
+          priorityBtnStyle
+        )}
+        <Text style={styles.sectionTitle}>Dificultad</Text>
+        {renderFullRow(
+          difficultyOptions,
+          difficultyFilter,
+          setDifficultyFilter,
+          styles.difficultyBtn,
+          difficultyBtnStyle
+        )}
+        <Text style={styles.sectionTitle}>Etiquetas</Text>
+        <View
+          style={[
+            styles.tagSearchContainer,
+            tagSearchFocused && styles.tagSearchContainerFocused,
+          ]}
       >
         <TextInput
           style={styles.tagSearchInput}

--- a/src/components/AdvancedFilters/AdvancedFilters.styles.js
+++ b/src/components/AdvancedFilters/AdvancedFilters.styles.js
@@ -25,12 +25,6 @@ export default StyleSheet.create({
     marginTop: 0,
     marginBottom: Spacing.small,
   },
-  title: {
-    color: Colors.text,
-    fontSize: 16,
-    fontWeight: "600",
-    marginBottom: Spacing.small,
-  },
   row: {
     flexDirection: "row",
     marginBottom: Spacing.base,
@@ -50,12 +44,44 @@ export default StyleSheet.create({
   },
   priorityBtn: {
     ...baseBtn,
+    justifyContent: "center",
   },
   difficultyBtn: {
     ...baseBtn,
+    justifyContent: "center",
   },
   tagBtn: {
     ...baseBtn,
+    paddingVertical: 2,
+    paddingHorizontal: Spacing.tiny,
+    borderRadius: 6,
+    marginRight: Spacing.tiny,
+  },
+  tagText: {
+    color: Colors.text,
+    fontSize: 12,
+  },
+  tagSearchContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: Colors.filterBtnBg,
+    borderRadius: 8,
+    borderWidth: 0.5,
+    borderColor: Colors.text,
+    paddingHorizontal: Spacing.small,
+    paddingVertical: Spacing.tiny,
+    marginBottom: Spacing.base,
+  },
+  tagSearchContainerFocused: {
+    borderColor: Colors.accent,
+  },
+  tagSearchInput: {
+    flex: 1,
+    color: Colors.text,
+    paddingVertical: Spacing.tiny,
+  },
+  clearBtn: {
+    marginLeft: Spacing.small,
   },
   sectionTitle: {
     color: Colors.text,
@@ -68,5 +94,10 @@ export default StyleSheet.create({
     color: Colors.text,
     fontSize: 14,
     marginLeft: Spacing.small,
+  },
+  centerText: {
+    marginLeft: 0,
+    textAlign: "center",
+    flex: 1,
   },
 });

--- a/src/components/FilterBar/FilterBar.js
+++ b/src/components/FilterBar/FilterBar.js
@@ -14,6 +14,7 @@ export default function FilterBar({ filters, active, onSelect }) {
           horizontal
           showsHorizontalScrollIndicator={false}
           style={styles.container}
+          contentContainerStyle={styles.contentContainer}
         >
           {filters.map((f) => {
             const Icon = ["single", "completed", "deleted"].includes(f.key)

--- a/src/components/FilterBar/FilterBar.styles.js
+++ b/src/components/FilterBar/FilterBar.styles.js
@@ -22,6 +22,11 @@ export default StyleSheet.create({
   container: {
     flexGrow: 0,
   },
+  contentContainer: {
+    flexGrow: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
 
   // “botón” transparente (solo texto/ícono cambian)
   btn: {

--- a/src/components/TaskFilters.js
+++ b/src/components/TaskFilters.js
@@ -47,6 +47,7 @@ export default function TaskFilters({
           <FontAwesome5 name="times" size={16} color={Colors.text} />
         </TouchableOpacity>
       )}
+      <Text style={styles.title}>Filtros avanzados</Text>
       <FilterBar filters={filters} active={active} onSelect={setActive} />
       <AdvancedFilters
         elementOptions={elementOptions}
@@ -78,6 +79,12 @@ const styles = StyleSheet.create({
   closeBtn: {
     alignSelf: "flex-end",
     padding: Spacing.tiny,
+  },
+  title: {
+    color: Colors.text,
+    fontSize: 16,
+    fontWeight: "600",
+    marginBottom: Spacing.small,
   },
   buttons: {
     flexDirection: "row",


### PR DESCRIPTION
## Summary
- move advanced filters title above filter bar and center filter bar items
- center priority/difficulty button text and fine-tune tag styles

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68992aa10b748327be6e21277f542e91