### PR TITLE
fix: improve subtask tagging UX

### DIFF
--- a/src/components/CreateTaskModal/CreateTaskModal.js
+++ b/src/components/CreateTaskModal/CreateTaskModal.js
@@ -8,6 +8,9 @@ import {
   TouchableOpacity,
   TextInput,
   ScrollView,
+  Alert,
+  Platform,
+  ToastAndroid,
 } from "react-native";
 import { FontAwesome5 } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
@@ -79,7 +82,10 @@ export default function CreateTaskModal({
   const [newSubtasks, setNewSubtasks] = useState([]);
 
   const handleSave = () => {
-    if (!newTitle.trim()) return;
+    if (!newTitle.trim()) {
+      Alert.alert("Falta título", "Debes ingresar un título para la tarea.");
+      return;
+    }
     onSave({
       title: newTitle,
       note: newNote,
@@ -120,6 +126,7 @@ export default function CreateTaskModal({
             style={{ width: "100%" }}
             contentContainerStyle={{ paddingBottom: Spacing.large }}
             showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
           >
             <Text style={styles.title}>Crear Nueva Tarea</Text>
 
@@ -351,13 +358,16 @@ export default function CreateTaskModal({
                   if (!tag) return;
                   setNewTags((prev) => [...new Set([...prev, tag])]);
                   setNewTagInput("");
+                  if (Platform.OS === "android") {
+                    ToastAndroid.show("Etiqueta creada", ToastAndroid.SHORT);
+                  }
                 }}
               >
                 <FontAwesome5 name="plus" size={12} color={Colors.background} />
               </TouchableOpacity>
             </View>
             {uniqueTags.length > 0 && (
-              <Text style={styles.label}>Selecciona etiquetas</Text>
+              <Text style={styles.label}>Mis Etiquetas</Text>
             )}
             {uniqueTags.length > 0 && (
               <ScrollView
@@ -401,18 +411,21 @@ export default function CreateTaskModal({
             )}
 
             {newTags.length > 0 && (
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                style={styles.row}
-                contentContainerStyle={{ alignItems: "center" }}
-              >
-                {newTags.map((tag) => (
-                  <View key={tag} style={styles.tagChip}>
-                    <Text style={styles.tagText}>{tag}</Text>
-                  </View>
-                ))}
-              </ScrollView>
+              <>
+                <Text style={styles.selectedTagsLabel}>Etiquetas seleccionadas</Text>
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  style={styles.row}
+                  contentContainerStyle={{ alignItems: "center" }}
+                >
+                  {newTags.map((tag) => (
+                    <View key={tag} style={styles.tagChip}>
+                      <Text style={styles.tagText}>{tag}</Text>
+                    </View>
+                  ))}
+                </ScrollView>
+              </>
             )}
 
             <View

--- a/src/components/CreateTaskModal/CreateTaskModal.styles.js
+++ b/src/components/CreateTaskModal/CreateTaskModal.styles.js
@@ -175,6 +175,12 @@ export default StyleSheet.create({
     color: Colors.text,
     fontSize: 12,
   },
+  selectedTagsLabel: {
+    color: Colors.text,
+    fontSize: 14,
+    fontWeight: "600",
+    marginBottom: Spacing.small,
+  },
   subtaskInputRow: {
     flexDirection: "row",
     alignItems: "center",
@@ -199,15 +205,22 @@ export default StyleSheet.create({
   },
   subtaskList: {
     marginTop: Spacing.small,
+    flexDirection: "row",
+    flexWrap: "wrap",
   },
   subtaskItem: {
-    flexDirection: "row",
-    alignItems: "center",
+    backgroundColor: Colors.surface,
+    borderRadius: 12,
+    borderWidth: 0.5,
+    borderColor: Colors.textMuted,
+    paddingHorizontal: Spacing.small,
+    paddingVertical: 4,
+    marginRight: Spacing.small,
     marginBottom: Spacing.small,
   },
   subtaskText: {
     color: Colors.text,
-    fontSize: 14,
+    fontSize: 12,
   },
   elementInfoBox: {
     backgroundColor: Colors.surface,


### PR DESCRIPTION
## Summary
- allow adding tags and subtasks even when the keyboard is open
- show subtasks as chips for clearer feedback
- alert when trying to save a task without a title
- show toast when creating a new tag
- rename tag picker to "Mis Etiquetas" and show "Etiquetas seleccionadas" subtitle

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68993c9c32408327b9241dd0b5f544d6