### PR TITLE
fix: improve subtask tagging UX

### DIFF
--- a/src/components/CreateTaskModal/CreateTaskModal.js
+++ b/src/components/CreateTaskModal/CreateTaskModal.js
@@ -77,9 +77,18 @@ export default function CreateTaskModal({
   const [newTags, setNewTags] = useState([]);
   const [newSubtaskInput, setNewSubtaskInput] = useState("");
   const [newSubtasks, setNewSubtasks] = useState([]);
+  const [alert, setAlert] = useState(null); // { message, type }
+
+  const showAlert = (message, type = "info") => {
+    setAlert({ message, type });
+    setTimeout(() => setAlert(null), 3000);
+  };
 
   const handleSave = () => {
-    if (!newTitle.trim()) return;
+    if (!newTitle.trim()) {
+      showAlert("Debes ingresar un título para la tarea.", "error");
+      return;
+    }
     onSave({
       title: newTitle,
       note: newNote,
@@ -116,10 +125,23 @@ export default function CreateTaskModal({
     >
       <View style={styles.background}>
         <View style={styles.container}>
+          {alert && (
+            <View
+              style={[
+                styles.alertContainer,
+                alert.type === "error"
+                  ? styles.alertError
+                  : styles.alertSuccess,
+              ]}
+            >
+              <Text style={styles.alertText}>{alert.message}</Text>
+            </View>
+          )}
           <ScrollView
             style={{ width: "100%" }}
             contentContainerStyle={{ paddingBottom: Spacing.large }}
             showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
           >
             <Text style={styles.title}>Crear Nueva Tarea</Text>
 
@@ -351,13 +373,14 @@ export default function CreateTaskModal({
                   if (!tag) return;
                   setNewTags((prev) => [...new Set([...prev, tag])]);
                   setNewTagInput("");
+                  showAlert("Etiqueta creada", "success");
                 }}
               >
                 <FontAwesome5 name="plus" size={12} color={Colors.background} />
               </TouchableOpacity>
             </View>
             {uniqueTags.length > 0 && (
-              <Text style={styles.label}>Selecciona etiquetas</Text>
+              <Text style={styles.label}>Mis Etiquetas</Text>
             )}
             {uniqueTags.length > 0 && (
               <ScrollView
@@ -401,18 +424,21 @@ export default function CreateTaskModal({
             )}
 
             {newTags.length > 0 && (
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                style={styles.row}
-                contentContainerStyle={{ alignItems: "center" }}
-              >
-                {newTags.map((tag) => (
-                  <View key={tag} style={styles.tagChip}>
-                    <Text style={styles.tagText}>{tag}</Text>
-                  </View>
-                ))}
-              </ScrollView>
+              <>
+                <Text style={styles.selectedTagsLabel}>Etiquetas seleccionadas</Text>
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  style={styles.row}
+                  contentContainerStyle={{ alignItems: "center" }}
+                >
+                  {newTags.map((tag) => (
+                    <View key={tag} style={styles.tagChip}>
+                      <Text style={styles.tagText}>{tag}</Text>
+                    </View>
+                  ))}
+                </ScrollView>
+              </>
             )}
 
             <View

--- a/src/components/CreateTaskModal/CreateTaskModal.styles.js
+++ b/src/components/CreateTaskModal/CreateTaskModal.styles.js
@@ -175,6 +175,12 @@ export default StyleSheet.create({
     color: Colors.text,
     fontSize: 12,
   },
+  selectedTagsLabel: {
+    color: Colors.text,
+    fontSize: 14,
+    fontWeight: "600",
+    marginBottom: Spacing.small,
+  },
   subtaskInputRow: {
     flexDirection: "row",
     alignItems: "center",
@@ -199,15 +205,22 @@ export default StyleSheet.create({
   },
   subtaskList: {
     marginTop: Spacing.small,
+    flexDirection: "row",
+    flexWrap: "wrap",
   },
   subtaskItem: {
-    flexDirection: "row",
-    alignItems: "center",
+    backgroundColor: Colors.surface,
+    borderRadius: 12,
+    borderWidth: 0.5,
+    borderColor: Colors.textMuted,
+    paddingHorizontal: Spacing.small,
+    paddingVertical: 4,
+    marginRight: Spacing.small,
     marginBottom: Spacing.small,
   },
   subtaskText: {
     color: Colors.text,
-    fontSize: 14,
+    fontSize: 12,
   },
   elementInfoBox: {
     backgroundColor: Colors.surface,
@@ -234,5 +247,27 @@ export default StyleSheet.create({
   elementInfoPurpose: {
     color: Colors.text,
     fontSize: 12,
+  },
+  alertContainer: {
+    position: "absolute",
+    bottom: Spacing.xlarge,
+    left: Spacing.base,
+    right: Spacing.base,
+    paddingVertical: Spacing.small,
+    paddingHorizontal: Spacing.base,
+    borderRadius: 8,
+    zIndex: 2,
+    alignItems: "center",
+  },
+  alertText: {
+    color: Colors.text,
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  alertSuccess: {
+    backgroundColor: Colors.secondary,
+  },
+  alertError: {
+    backgroundColor: Colors.danger,
   },
 });


### PR DESCRIPTION
## Summary
- allow adding tags and subtasks even when the keyboard is open
- show subtasks as chips for clearer feedback
- alert when trying to save a task without a title
- rename tag picker to "Mis Etiquetas" and show "Etiquetas seleccionadas" subtitle
- replace system alerts with themed in-app alerts for missing titles and new tags
- reposition alerts closer to the keyboard and lengthen their display time

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68993c9c32408327b9241dd0b5f544d6