### PR TITLE
refactor: replace difficulty chip with type chip

### DIFF
--- a/src/components/SwipeableTaskItem/SwipeableTaskItem.js
+++ b/src/components/SwipeableTaskItem/SwipeableTaskItem.js
@@ -53,16 +53,14 @@ const getPriorityLabel = (p) => {
   }
 };
 
-const getDifficultyColor = (d) => {
-  switch (d) {
-    case "easy":
-      return Colors.secondary;
-    case "medium":
-      return Colors.accent;
-    case "hard":
-      return Colors.danger;
+const getTypeConfig = (type) => {
+  switch (type) {
+    case "habit":
+      return { label: "Hábito", color: Colors.secondaryLight };
+    case "single":
+      return { label: "Tarea", color: Colors.primaryLight };
     default:
-      return Colors.text;
+      return { label: "Tarea", color: Colors.primaryLight };
   }
 };
 
@@ -110,6 +108,7 @@ export default function SwipeableTaskItem({
   // Información del elemento (icono y color)
   // se usa una función para evitar lógica compleja en el render
   const elementInfo = getElementColor(task.element);
+  const typeConfig = getTypeConfig(task.type);
   const [showSubtasks, setShowSubtasks] = useState(false);
 
   // Estilos de acción al deslizar
@@ -175,7 +174,7 @@ export default function SwipeableTaskItem({
           {
             transform: [{ translateX: pan }],
             opacity: task.completed || task.isDeleted ? 0.5 : 1,
-            borderLeftColor: getDifficultyColor(task.difficulty),
+            borderLeftColor: getPriorityColor(task.priority),
           },
         ]}
         {...panResponder.panHandlers}
@@ -302,7 +301,7 @@ export default function SwipeableTaskItem({
           </>
         )}
 
-        {/* ——— Badges de Elemento y Dificultad ——— */}
+        {/* ——— Badges de Elemento y Tipo ——— */}
         <View style={styles.badgeRow}>
           {/* Elemento (solo icono) */}
           <View
@@ -319,21 +318,12 @@ export default function SwipeableTaskItem({
               color={Colors.background}
             />
           </View>
-          {/* Dificultad */}
+          {/* Tipo */}
           <View
-            style={[
-              styles.badge,
-              { backgroundColor: getDifficultyColor(task.difficulty) },
-            ]}
+            style={[styles.badge, { backgroundColor: typeConfig.color }]}
           >
-            <FontAwesome5
-              name="lightbulb"
-              size={12}
-              color={Colors.background}
-              style={styles.badgeIcon}
-            />
-            <Text style={[styles.badgeText, { color: Colors.background }]}>
-              {task.difficulty}
+            <Text style={[styles.badgeText, { color: Colors.text }]}>
+              {typeConfig.label}
             </Text>
           </View>
           {/* Prioridad (chip con borde) */}

--- a/src/components/SwipeableTaskItem/SwipeableTaskItem.styles.js
+++ b/src/components/SwipeableTaskItem/SwipeableTaskItem.styles.js
@@ -160,7 +160,7 @@ export default StyleSheet.create({
     elevation: 2,
   },
 
-  // badges de dificultad:
+  // fila de badges (elemento, tipo, prioridad):
   badgeRow: {
     flexDirection: "row",
     marginTop: Spacing.small,
@@ -173,9 +173,6 @@ export default StyleSheet.create({
     paddingVertical: Spacing.tiny,
     marginRight: Spacing.small,
     marginTop: 1,
-  },
-  badgeIcon: {
-    marginRight: Spacing.tiny,
   },
   badgeText: {
     fontSize: 12,


### PR DESCRIPTION
## Summary
- show task type chip instead of difficulty
- color task card border by priority
- remove unused badge styles
- fix type badge rendering

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689949268ec083279efbbb9e99fb03b4