### PR TITLE
Cerrar modal al limpiar filtros avanzados

### DIFF
--- a/src/components/TaskFilters.js
+++ b/src/components/TaskFilters.js
@@ -39,6 +39,17 @@ export default function TaskFilters({
     setPriorityFilter("all");
     setDifficultyFilter("all");
     setTagFilter("all");
+    if (onSelect) {
+      onSelect({
+        active: "all",
+        elementFilter: "all",
+        priorityFilter: "all",
+        difficultyFilter: "all",
+        tagFilter: "all",
+      });
+    } else if (onClose) {
+      onClose();
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- Cerrar el modal de filtros avanzados al presionar **Limpiar Filtros**
- Resetear y enviar filtros por defecto al componente padre para que se apliquen

## Testing
- `npm test` *(falla: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689951d181e8832781029c301acb0abb