### PR TITLE
feat: add bottom tab navigation

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,65 +1,30 @@
-// App.js
-
-import React, { useState } from "react";
-import { SafeAreaView, StyleSheet, View, Text } from "react-native";
+import React from "react";
+import { NavigationContainer } from "@react-navigation/native";
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { Colors } from "./src/theme";
-import TasksScreen from "./src/screens/TasksScreen";
+
 import Footer from "./src/components/Footer";
+import HomeScreen from "./src/screens/HomeScreen";
+import TasksScreen from "./src/screens/TasksScreen";
+import MiPlantaScreen from "./src/screens/MiPlantaScreen";
+import ProfileScreen from "./src/screens/ProfileScreen";
+
+const Tab = createBottomTabNavigator();
 
 export default function App() {
-  const [activeScreen, setActiveScreen] = useState("tasks");
-
-  const handleNavigate = (screen) => {
-    setActiveScreen(screen);
-  };
-
-  const renderScreen = () => {
-    switch (activeScreen) {
-      case "tasks":
-        return <TasksScreen />;
-      case "plant":
-        return (
-          <View style={styles.placeholder}>
-            <Text style={styles.placeholderText}>Planta</Text>
-          </View>
-        );
-      case "stats":
-        return (
-          <View style={styles.placeholder}>
-            <Text style={styles.placeholderText}>Estadísticas</Text>
-          </View>
-        );
-      case "profile":
-        return (
-          <View style={styles.placeholder}>
-            <Text style={styles.placeholderText}>Perfil</Text>
-          </View>
-        );
-      default:
-        return null;
-    }
-  };
-
   return (
-    <SafeAreaView style={styles.container}>
-      {renderScreen()}
-      <Footer activeScreen={activeScreen} onNavigate={handleNavigate} />
-    </SafeAreaView>
+    <NavigationContainer>
+      <Tab.Navigator
+        initialRouteName="HomeScreen"
+        screenOptions={{ headerShown: false }}
+        tabBar={(props) => <Footer {...props} />}
+        sceneContainerStyle={{ backgroundColor: Colors.background }}
+      >
+        <Tab.Screen name="HomeScreen" component={HomeScreen} />
+        <Tab.Screen name="TasksScreen" component={TasksScreen} />
+        <Tab.Screen name="MiPlantaScreen" component={MiPlantaScreen} />
+        <Tab.Screen name="ProfileScreen" component={ProfileScreen} />
+      </Tab.Navigator>
+    </NavigationContainer>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.background, // <-- aquí usamos tu token de tema
-  },
-  placeholder: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  placeholderText: {
-    color: Colors.text,
-    fontSize: 16,
-  },
-});

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -6,17 +6,17 @@ import { LinearGradient } from "expo-linear-gradient";
 import styles from "./Footer.styles";
 
 const NAV_ITEMS = [
-  { route: "Home", label: "Inicio", icon: "home" },
-  { route: "Tasks", label: "Tareas", icon: "tasks" },
-  { route: "Plant", label: "Mi Planta", icon: "leaf" },
-  { route: "Profile", label: "Perfil", icon: "user" },
+  { route: "HomeScreen", label: "Inicio", icon: "home" },
+  { route: "TasksScreen", label: "Tareas", icon: "tasks" },
+  { route: "MiPlantaScreen", label: "Mi Planta", icon: "leaf" },
+  { route: "ProfileScreen", label: "Perfil", icon: "user" },
 ];
 
-export default function Footer({ navigation, activeRoute }) {
+export default function Footer({ state, navigation }) {
   return (
     <View style={styles.container}>
-      {NAV_ITEMS.map((item) => {
-        const isActive = activeRoute === item.route;
+      {NAV_ITEMS.map((item, index) => {
+        const isActive = state.index === index;
         return (
           <TouchableOpacity
             key={item.route}

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { Colors } from "../theme";
+
+export default function HomeScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Inicio</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: Colors.background,
+  },
+  text: {
+    color: Colors.text,
+    fontSize: 16,
+  },
+});

--- a/src/screens/MiPlantaScreen.js
+++ b/src/screens/MiPlantaScreen.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { Colors } from "../theme";
+
+export default function MiPlantaScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Mi Planta</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: Colors.background,
+  },
+  text: {
+    color: Colors.text,
+    fontSize: 16,
+  },
+});

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { Colors } from "../theme";
+
+export default function ProfileScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Perfil</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: Colors.background,
+  },
+  text: {
+    color: Colors.text,
+    fontSize: 16,
+  },
+});


### PR DESCRIPTION
## Summary
- replace state-based navigation with React Navigation bottom tabs
- update footer to work as custom tab bar
- add placeholder screens for home, plant and profile

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b998a439c8327845f816f86460c87