### PR TITLE
feat: add home screen header component

### DIFF
--- a/src/components/HomeScreenHeader.js
+++ b/src/components/HomeScreenHeader.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { View, Text } from "react-native";
+import { FontAwesome5, Ionicons } from "@expo/vector-icons";
+import { LinearGradient } from "expo-linear-gradient";
+
+import styles from "./HomeScreenHeader.styles";
+import { Colors } from "../theme";
+
+export default function HomeScreenHeader({ userName, manaCount, plantState }) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.greeting}>¡Hola, {userName}!</Text>
+      <View style={styles.statusContainer}>
+        <View style={styles.statusItem}>
+          <LinearGradient
+            colors={[Colors.primary, Colors.secondary]}
+            style={styles.iconBackground}
+          >
+            <FontAwesome5 name="leaf" size={16} color={Colors.text} />
+          </LinearGradient>
+          <Text style={styles.statusText}>{plantState}</Text>
+        </View>
+        <View style={styles.statusItem}>
+          <LinearGradient
+            colors={[Colors.secondary, Colors.primary]}
+            style={styles.iconBackground}
+          >
+            <Ionicons name="flash" size={16} color={Colors.text} />
+          </LinearGradient>
+          <Text style={styles.statusText}>{manaCount}</Text>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/src/components/HomeScreenHeader.styles.js
+++ b/src/components/HomeScreenHeader.styles.js
@@ -1,0 +1,36 @@
+import { StyleSheet } from "react-native";
+import { Colors, Spacing } from "../theme";
+
+export default StyleSheet.create({
+  container: {
+    backgroundColor: Colors.surface,
+    paddingHorizontal: Spacing.base,
+    paddingVertical: Spacing.base,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  greeting: {
+    fontSize: 24,
+    fontWeight: "bold",
+    color: Colors.text,
+  },
+  statusContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  statusItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginLeft: Spacing.base,
+  },
+  iconBackground: {
+    padding: Spacing.tiny,
+    borderRadius: 12,
+    marginRight: Spacing.tiny,
+  },
+  statusText: {
+    color: Colors.text,
+    fontSize: 16,
+  },
+});


### PR DESCRIPTION
## Summary
- add reusable `HomeScreenHeader` component with greeting and status icons
- style header with dark theme colors and gradient icon backgrounds
- use theme colors for icons

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b9c40254c8327ae829c0a5ea587b1