### PR TITLE
Replace home screen text with HomeScreenHeader

### DIFF
--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,11 +1,16 @@
 import React from "react";
-import { View, Text, StyleSheet } from "react-native";
+import { View, StyleSheet } from "react-native";
 import { Colors } from "../theme";
+import HomeScreenHeader from "../components/HomeScreenHeader";
 
 export default function HomeScreen() {
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>Inicio</Text>
+      <HomeScreenHeader
+        userName="Jugador"
+        manaCount={50}
+        plantState="Floreciendo"
+      />
     </View>
   );
 }
@@ -13,12 +18,8 @@ export default function HomeScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
+    justifyContent: "flex-start",
+    alignItems: "stretch",
     backgroundColor: Colors.background,
-  },
-  text: {
-    color: Colors.text,
-    fontSize: 16,
   },
 });


### PR DESCRIPTION
## Summary
- Display HomeScreenHeader in HomeScreen with sample user, mana, and plant state
- Adjust home screen container styles to align header at the top

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ba01606f88327a87a863f0d6c09d3