### PR TITLE
feat(home): add placeholder home sections

### DIFF
--- a/src/components/home/DailyChallengesSection.js
+++ b/src/components/home/DailyChallengesSection.js
@@ -1,0 +1,17 @@
+// [MB] Módulo: Home / Componente: DailyChallengesSection
+// Afecta: HomeScreen
+// Propósito: Sección placeholder para desafíos diarios
+// Puntos de edición futura: añadir lista de desafíos y acciones
+// Autor: Codex - Fecha: 2025-08-12
+
+import React from "react";
+import { View, Text } from "react-native";
+import styles from "./DailyChallengesSection.styles";
+
+export default function DailyChallengesSection() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Desafíos Diarios</Text>
+    </View>
+  );
+}

--- a/src/components/home/DailyChallengesSection.styles.js
+++ b/src/components/home/DailyChallengesSection.styles.js
@@ -1,0 +1,28 @@
+// [MB] Módulo: Home / Estilos: DailyChallengesSection
+// Afecta: HomeScreen
+// Propósito: Estilos placeholder para la sección de desafíos diarios
+// Puntos de edición futura: manejar lista dinámica y estados
+// Autor: Codex - Fecha: 2025-08-12
+
+import { StyleSheet } from "react-native";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Elevation,
+  Typography,
+} from "../../theme";
+
+export default StyleSheet.create({
+  container: {
+    backgroundColor: Colors.surface,
+    padding: Spacing.base,
+    borderRadius: Radii.md,
+    marginBottom: Spacing.large,
+    ...Elevation.card,
+  },
+  title: {
+    ...Typography.h2,
+    color: Colors.text,
+  },
+});

--- a/src/components/home/EventBanner.js
+++ b/src/components/home/EventBanner.js
@@ -1,0 +1,17 @@
+// [MB] Módulo: Home / Componente: EventBanner
+// Afecta: HomeScreen
+// Propósito: Banner placeholder para eventos
+// Puntos de edición futura: reemplazar por promoción dinámica
+// Autor: Codex - Fecha: 2025-08-12
+
+import React from "react";
+import { View, Text } from "react-native";
+import styles from "./EventBanner.styles";
+
+export default function EventBanner() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Próximo Evento</Text>
+    </View>
+  );
+}

--- a/src/components/home/EventBanner.styles.js
+++ b/src/components/home/EventBanner.styles.js
@@ -1,0 +1,28 @@
+// [MB] Módulo: Home / Estilos: EventBanner
+// Afecta: HomeScreen
+// Propósito: Estilos placeholder para banner de eventos
+// Puntos de edición futura: agregar imágenes y enlaces
+// Autor: Codex - Fecha: 2025-08-12
+
+import { StyleSheet } from "react-native";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Elevation,
+  Typography,
+} from "../../theme";
+
+export default StyleSheet.create({
+  container: {
+    backgroundColor: Colors.surface,
+    padding: Spacing.base,
+    borderRadius: Radii.md,
+    marginBottom: Spacing.large,
+    ...Elevation.card,
+  },
+  title: {
+    ...Typography.h2,
+    color: Colors.text,
+  },
+});

--- a/src/components/home/HomeWelcomeCard.js
+++ b/src/components/home/HomeWelcomeCard.js
@@ -1,0 +1,17 @@
+// [MB] Módulo: Home / Componente: HomeWelcomeCard
+// Afecta: HomeScreen
+// Propósito: Tarjeta de bienvenida placeholder para el usuario
+// Puntos de edición futura: reemplazar por contenido dinámico
+// Autor: Codex - Fecha: 2025-08-12
+
+import React from "react";
+import { View, Text } from "react-native";
+import styles from "./HomeWelcomeCard.styles";
+
+export default function HomeWelcomeCard() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Bienvenido de vuelta</Text>
+    </View>
+  );
+}

--- a/src/components/home/HomeWelcomeCard.styles.js
+++ b/src/components/home/HomeWelcomeCard.styles.js
@@ -1,0 +1,28 @@
+// [MB] Módulo: Home / Estilos: HomeWelcomeCard
+// Afecta: HomeScreen
+// Propósito: Estilos placeholder para tarjeta de bienvenida
+// Puntos de edición futura: ajustar layout y gráficos
+// Autor: Codex - Fecha: 2025-08-12
+
+import { StyleSheet } from "react-native";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Elevation,
+  Typography,
+} from "../../theme";
+
+export default StyleSheet.create({
+  container: {
+    backgroundColor: Colors.surface,
+    padding: Spacing.base,
+    borderRadius: Radii.md,
+    marginBottom: Spacing.large,
+    ...Elevation.card,
+  },
+  title: {
+    ...Typography.h2,
+    color: Colors.text,
+  },
+});

--- a/src/components/home/MagicShopSection.js
+++ b/src/components/home/MagicShopSection.js
@@ -1,0 +1,17 @@
+// [MB] Módulo: Home / Componente: MagicShopSection
+// Afecta: HomeScreen
+// Propósito: Sección placeholder para la tienda mágica
+// Puntos de edición futura: integrar productos y navegación
+// Autor: Codex - Fecha: 2025-08-12
+
+import React from "react";
+import { View, Text } from "react-native";
+import styles from "./MagicShopSection.styles";
+
+export default function MagicShopSection() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Tienda Mágica</Text>
+    </View>
+  );
+}

--- a/src/components/home/MagicShopSection.styles.js
+++ b/src/components/home/MagicShopSection.styles.js
@@ -1,0 +1,28 @@
+// [MB] Módulo: Home / Estilos: MagicShopSection
+// Afecta: HomeScreen
+// Propósito: Estilos placeholder para sección de tienda
+// Puntos de edición futura: diferenciar categorías y tarjetas
+// Autor: Codex - Fecha: 2025-08-12
+
+import { StyleSheet } from "react-native";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Elevation,
+  Typography,
+} from "../../theme";
+
+export default StyleSheet.create({
+  container: {
+    backgroundColor: Colors.surface,
+    padding: Spacing.base,
+    borderRadius: Radii.md,
+    marginBottom: Spacing.large,
+    ...Elevation.card,
+  },
+  title: {
+    ...Typography.h2,
+    color: Colors.text,
+  },
+});

--- a/src/components/home/NewsFeedSection.js
+++ b/src/components/home/NewsFeedSection.js
@@ -1,0 +1,17 @@
+// [MB] Módulo: Home / Componente: NewsFeedSection
+// Afecta: HomeScreen
+// Propósito: Sección placeholder para noticias
+// Puntos de edición futura: conectar con feed real
+// Autor: Codex - Fecha: 2025-08-12
+
+import React from "react";
+import { View, Text } from "react-native";
+import styles from "./NewsFeedSection.styles";
+
+export default function NewsFeedSection() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Noticias</Text>
+    </View>
+  );
+}

--- a/src/components/home/NewsFeedSection.styles.js
+++ b/src/components/home/NewsFeedSection.styles.js
@@ -1,0 +1,28 @@
+// [MB] Módulo: Home / Estilos: NewsFeedSection
+// Afecta: HomeScreen
+// Propósito: Estilos placeholder para feed de noticias
+// Puntos de edición futura: manejar lista y tarjetas
+// Autor: Codex - Fecha: 2025-08-12
+
+import { StyleSheet } from "react-native";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Elevation,
+  Typography,
+} from "../../theme";
+
+export default StyleSheet.create({
+  container: {
+    backgroundColor: Colors.surface,
+    padding: Spacing.base,
+    borderRadius: Radii.md,
+    marginBottom: Spacing.large,
+    ...Elevation.card,
+  },
+  title: {
+    ...Typography.h2,
+    color: Colors.text,
+  },
+});

--- a/src/components/home/StatsQuickTiles.js
+++ b/src/components/home/StatsQuickTiles.js
@@ -1,0 +1,28 @@
+// [MB] Módulo: Home / Componente: StatsQuickTiles
+// Afecta: HomeScreen
+// Propósito: Contenedor placeholder para estadísticas rápidas
+// Puntos de edición futura: mostrar valores reales y gráficos
+// Autor: Codex - Fecha: 2025-08-12
+
+import React from "react";
+import { View, Text } from "react-native";
+import styles from "./StatsQuickTiles.styles";
+
+export default function StatsQuickTiles() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Estadísticas</Text>
+      <View style={styles.tiles}>
+        <View style={styles.tile}>
+          <Text style={styles.tileText}>Maná</Text>
+        </View>
+        <View style={styles.tile}>
+          <Text style={styles.tileText}>XP</Text>
+        </View>
+        <View style={styles.tile}>
+          <Text style={styles.tileText}>Racha</Text>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/src/components/home/StatsQuickTiles.styles.js
+++ b/src/components/home/StatsQuickTiles.styles.js
@@ -1,0 +1,46 @@
+// [MB] Módulo: Home / Estilos: StatsQuickTiles
+// Afecta: HomeScreen
+// Propósito: Estilos placeholder para estadísticas rápidas
+// Puntos de edición futura: ajustar layout de mosaicos
+// Autor: Codex - Fecha: 2025-08-12
+
+import { StyleSheet } from "react-native";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Elevation,
+  Typography,
+} from "../../theme";
+
+export default StyleSheet.create({
+  container: {
+    backgroundColor: Colors.surface,
+    padding: Spacing.base,
+    borderRadius: Radii.md,
+    marginBottom: Spacing.large,
+    ...Elevation.card,
+  },
+  title: {
+    ...Typography.h2,
+    color: Colors.text,
+  },
+  tiles: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginTop: Spacing.base,
+  },
+  tile: {
+    flex: 1,
+    backgroundColor: Colors.surfaceElevated,
+    padding: Spacing.small,
+    borderRadius: Radii.sm,
+    marginHorizontal: Spacing.tiny,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  tileText: {
+    ...Typography.caption,
+    color: Colors.text,
+  },
+});

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,8 +1,20 @@
+// [MB] Módulo: Home / Pantalla: HomeScreen
+// Afecta: HomeScreen (layout principal)
+// Propósito: Renderizar secciones placeholder de inicio
+// Puntos de edición futura: conectar datos reales y navegación
+// Autor: Codex - Fecha: 2025-08-12
+
 import React from "react";
-import { StyleSheet } from "react-native";
+import { StyleSheet, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { Colors } from "../theme";
+import { Colors, Spacing } from "../theme";
 import HomeScreenHeader from "../components/HomeScreenHeader";
+import HomeWelcomeCard from "../components/home/HomeWelcomeCard";
+import DailyChallengesSection from "../components/home/DailyChallengesSection";
+import MagicShopSection from "../components/home/MagicShopSection";
+import NewsFeedSection from "../components/home/NewsFeedSection";
+import StatsQuickTiles from "../components/home/StatsQuickTiles";
+import EventBanner from "../components/home/EventBanner";
 
 export default function HomeScreen() {
   return (
@@ -12,6 +24,19 @@ export default function HomeScreen() {
         manaCount={50}
         plantState="Floreciendo"
       />
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: Spacing.base,
+          paddingBottom: 96,
+        }}
+      >
+        <HomeWelcomeCard />
+        <DailyChallengesSection />
+        <MagicShopSection />
+        <NewsFeedSection />
+        <StatsQuickTiles />
+        <EventBanner />
+      </ScrollView>
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
## Summary
- scaffold Home screen sections with basic UI placeholders
- wrap HomeScreen in SafeAreaView and ScrollView with padding
- integrate new sections: welcome, challenges, shop, news, stats, and event banner

## Testing
- `npm test`
- `EXPO_OFFLINE=1 npm run start` (bundle starts)


------
https://chatgpt.com/codex/tasks/task_e_689baef12ad88327b8111cb824a0d612