### PR TITLE
feat(home/shop): UI de Tienda Mágica con tabs y cards

### DIFF
--- a/src/components/home/MagicShopSection.js
+++ b/src/components/home/MagicShopSection.js
@@ -4,14 +4,81 @@
 // Puntos de edición futura: integrar productos y navegación
 // Autor: Codex - Fecha: 2025-08-12
 
-import React from "react";
-import { View, Text } from "react-native";
+import React, { useState } from "react";
+import { View, Text, Pressable } from "react-native";
 import styles from "./MagicShopSection.styles";
+import ShopItemCard from "./ShopItemCard";
+import { ShopColors } from "../../theme";
+
+const TABS = [
+  { key: "potions", label: "Pociones" },
+  { key: "tools", label: "Herramientas" },
+  { key: "cosmetics", label: "Cosméticos" },
+];
+
+const SHOP_ITEMS = {
+  potions: [
+    { id: "p1", title: "Poción de Sabiduría", description: "Duplica XP por 2 horas", price: 50, iconName: "flask" },
+    { id: "p2", title: "Cristal de Maná", description: "+100 maná instantáneo", price: 30, iconName: "diamond" },
+  ],
+  tools: [
+    { id: "t1", title: "Varita Élfica", description: "Reduce dificultad por 1 día", price: 120, iconName: "construct" },
+    { id: "t2", title: "Escudo Temporal", description: "Protege racha por 1 día", price: 80, iconName: "shield" },
+  ],
+  cosmetics: [
+    { id: "c1", title: "Maceta Dorada", description: "Mejora visual de la planta", price: 200, iconName: "color-palette" },
+  ],
+};
 
 export default function MagicShopSection() {
+  const [activeTab, setActiveTab] = useState("potions");
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Tienda Mágica</Text>
+
+      <View style={styles.tabsRow}>
+        {TABS.map((tab, index) => {
+          const isActive = tab.key === activeTab;
+          const accent = ShopColors[tab.key];
+          return (
+            <Pressable
+              key={tab.key}
+              onPress={() => setActiveTab(tab.key)}
+              style={[
+                styles.tabButton,
+                index === TABS.length - 1 && { marginRight: 0 },
+                isActive && { backgroundColor: accent.bg, borderColor: accent.border },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={`Mostrar ${tab.label}`}
+            >
+              <Text style={styles.tabText}>{tab.label}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {SHOP_ITEMS[activeTab].map((item) => (
+        <View key={item.id} style={styles.itemWrapper}>
+          <ShopItemCard
+            title={item.title}
+            description={item.description}
+            price={item.price}
+            iconName={item.iconName}
+            accent={ShopColors[activeTab]}
+            accessibilityLabel={`Comprar ${item.title} por ${item.price} maná`}
+          />
+        </View>
+      ))}
+
+      <Pressable
+        style={styles.viewAllButton}
+        accessibilityRole="button"
+        accessibilityLabel="Ver todos los artículos"
+      >
+        <Text style={styles.viewAllText}>Ver todos los artículos</Text>
+      </Pressable>
     </View>
   );
 }

--- a/src/components/home/MagicShopSection.styles.js
+++ b/src/components/home/MagicShopSection.styles.js
@@ -1,6 +1,6 @@
 // [MB] Módulo: Home / Estilos: MagicShopSection
 // Afecta: HomeScreen
-// Propósito: Estilos placeholder para sección de tienda
+// Propósito: Estilos para sección de tienda mágica con tabs y cards
 // Puntos de edición futura: diferenciar categorías y tarjetas
 // Autor: Codex - Fecha: 2025-08-12
 
@@ -23,6 +23,40 @@ export default StyleSheet.create({
   },
   title: {
     ...Typography.h2,
+    color: Colors.text,
+  },
+  tabsRow: {
+    flexDirection: "row",
+    marginTop: Spacing.base,
+  },
+  tabButton: {
+    flex: 1,
+    height: 40,
+    paddingHorizontal: Spacing.base,
+    borderRadius: Radii.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    justifyContent: "center",
+    alignItems: "center",
+    marginRight: Spacing.small,
+  },
+  tabText: {
+    ...Typography.body,
+    color: Colors.text,
+  },
+  itemWrapper: {
+    marginTop: Spacing.base,
+  },
+  viewAllButton: {
+    marginTop: Spacing.base,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: Radii.md,
+    paddingVertical: Spacing.small,
+    alignItems: "center",
+  },
+  viewAllText: {
+    ...Typography.body,
     color: Colors.text,
   },
 });

--- a/src/components/home/ShopItemCard.js
+++ b/src/components/home/ShopItemCard.js
@@ -1,0 +1,44 @@
+// [MB] Módulo: Home / Sección: Tienda Mágica (Pestañas)
+// Afecta: HomeScreen (layout principal)
+// Propósito: Card de item reutilizable para la tienda mágica
+// Puntos de edición futura: integrar lógica de compra y selección
+// Autor: Codex - Fecha: 2025-08-12
+
+import React from "react";
+import { Pressable, View, Text } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import styles from "./ShopItemCard.styles";
+import { Colors } from "../../theme";
+
+export default function ShopItemCard({
+  title,
+  description,
+  price,
+  iconName,
+  accent,
+  selected,
+  onPress,
+  ...rest
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[
+        styles.card,
+        { borderColor: accent.border },
+        selected && { borderColor: accent.pill, shadowColor: accent.pill },
+      ]}
+      accessibilityRole="button"
+      {...rest}
+    >
+      <View style={styles.info}>
+        <Text style={styles.title}>{title}</Text>
+        <Text style={styles.description}>{description}</Text>
+      </View>
+      <View style={[styles.pill, { backgroundColor: accent.pill }]}>
+        <Ionicons name={iconName} size={16} color={Colors.textInverse} />
+        <Text style={styles.pillText}>{price}</Text>
+      </View>
+    </Pressable>
+  );
+}

--- a/src/components/home/ShopItemCard.styles.js
+++ b/src/components/home/ShopItemCard.styles.js
@@ -1,0 +1,52 @@
+// [MB] Módulo: Home / Estilos: ShopItemCard (Tienda Mágica)
+// Afecta: HomeScreen (layout principal)
+// Propósito: Estilos para card de item de la tienda
+// Puntos de edición futura: ajustar tipografía y sombras
+// Autor: Codex - Fecha: 2025-08-12
+
+import { StyleSheet } from "react-native";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Elevation,
+  Typography,
+} from "../../theme";
+
+export default StyleSheet.create({
+  card: {
+    backgroundColor: Colors.surfaceElevated,
+    borderWidth: 1,
+    borderRadius: Radii.lg,
+    padding: Spacing.base,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    ...Elevation.card,
+  },
+  info: {
+    flex: 1,
+    marginRight: Spacing.small,
+  },
+  title: {
+    ...Typography.title,
+    color: Colors.text,
+  },
+  description: {
+    ...Typography.body,
+    color: Colors.textMuted,
+    marginTop: Spacing.small,
+  },
+  pill: {
+    flexDirection: "row",
+    alignItems: "center",
+    height: 32,
+    paddingHorizontal: Spacing.base,
+    borderRadius: Radii.pill,
+  },
+  pillText: {
+    ...Typography.body,
+    color: Colors.textInverse,
+    marginLeft: Spacing.small,
+  },
+});


### PR DESCRIPTION
## Summary
- MagicShopSection: tabs (Pociones/Herramientas/Cosméticos) con acentos ShopColors
- ShopItemCard: card reutilizable con pill de precio e ícono

## Testing
- `npm test`
- `npm run web` *(falló: TypeError fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689bb11f8d988327a9bcc53ee5ccaf3b