### PR TITLE
feat(state): add global mana and plant context

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,3 +1,9 @@
+// [MB] Módulo: Core / Archivo: App
+// Afecta: navegación global
+// Propósito: Configurar navegación y proveer contexto global
+// Puntos de edición futura: agregar providers adicionales
+// Autor: Codex - Fecha: 2025-08-12
+
 import React from "react";
 import { NavigationContainer } from "@react-navigation/native";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
@@ -8,23 +14,26 @@ import HomeScreen from "./src/screens/HomeScreen";
 import TasksScreen from "./src/screens/TasksScreen";
 import MiPlantaScreen from "./src/screens/MiPlantaScreen";
 import ProfileScreen from "./src/screens/ProfileScreen";
+import { AppProvider } from "./src/state/AppContext";
 
 const Tab = createBottomTabNavigator();
 
 export default function App() {
   return (
-    <NavigationContainer>
-      <Tab.Navigator
-        initialRouteName="HomeScreen"
-        screenOptions={{ headerShown: false }}
-        tabBar={(props) => <Footer {...props} />}
-        sceneContainerStyle={{ backgroundColor: Colors.background }}
-      >
-        <Tab.Screen name="HomeScreen" component={HomeScreen} />
-        <Tab.Screen name="TasksScreen" component={TasksScreen} />
-        <Tab.Screen name="MiPlantaScreen" component={MiPlantaScreen} />
-        <Tab.Screen name="ProfileScreen" component={ProfileScreen} />
-      </Tab.Navigator>
-    </NavigationContainer>
+    <AppProvider>
+      <NavigationContainer>
+        <Tab.Navigator
+          initialRouteName="HomeScreen"
+          screenOptions={{ headerShown: false }}
+          tabBar={(props) => <Footer {...props} />}
+          sceneContainerStyle={{ backgroundColor: Colors.background }}
+        >
+          <Tab.Screen name="HomeScreen" component={HomeScreen} />
+          <Tab.Screen name="TasksScreen" component={TasksScreen} />
+          <Tab.Screen name="MiPlantaScreen" component={MiPlantaScreen} />
+          <Tab.Screen name="ProfileScreen" component={ProfileScreen} />
+        </Tab.Navigator>
+      </NavigationContainer>
+    </AppProvider>
   );
 }

--- a/src/components/home/MagicShopSection.js
+++ b/src/components/home/MagicShopSection.js
@@ -1,6 +1,6 @@
 // [MB] Módulo: Home / Componente: MagicShopSection
 // Afecta: HomeScreen
-// Propósito: Sección placeholder para la tienda mágica
+// Propósito: Sección de tienda mágica con tabs y maná disponible
 // Puntos de edición futura: integrar productos y navegación
 // Autor: Codex - Fecha: 2025-08-12
 
@@ -9,6 +9,7 @@ import { View, Text, Pressable } from "react-native";
 import styles from "./MagicShopSection.styles";
 import ShopItemCard from "./ShopItemCard";
 import { ShopColors } from "../../theme";
+import { useAppState } from "../../state/AppContext";
 
 const TABS = [
   { key: "potions", label: "Pociones" },
@@ -32,10 +33,12 @@ const SHOP_ITEMS = {
 
 export default function MagicShopSection() {
   const [activeTab, setActiveTab] = useState("potions");
+  const { mana } = useAppState();
 
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Tienda Mágica</Text>
+      <Text style={styles.manaText}>Maná disponible: {mana}</Text>
 
       <View style={styles.tabsRow}>
         {TABS.map((tab, index) => {

--- a/src/components/home/MagicShopSection.styles.js
+++ b/src/components/home/MagicShopSection.styles.js
@@ -25,6 +25,11 @@ export default StyleSheet.create({
     ...Typography.h2,
     color: Colors.text,
   },
+  manaText: {
+    ...Typography.caption,
+    color: Colors.text,
+    marginTop: Spacing.small,
+  },
   tabsRow: {
     flexDirection: "row",
     marginTop: Spacing.base,

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,6 +1,6 @@
 // [MB] Módulo: Home / Pantalla: HomeScreen
 // Afecta: HomeScreen (layout principal)
-// Propósito: Renderizar secciones placeholder de inicio
+// Propósito: Renderizar secciones de inicio y mostrar estado global
 // Puntos de edición futura: conectar datos reales y navegación
 // Autor: Codex - Fecha: 2025-08-12
 
@@ -15,15 +15,14 @@ import MagicShopSection from "../components/home/MagicShopSection";
 import NewsFeedSection from "../components/home/NewsFeedSection";
 import StatsQuickTiles from "../components/home/StatsQuickTiles";
 import EventBanner from "../components/home/EventBanner";
+import { useAppState } from "../state/AppContext";
 
 export default function HomeScreen() {
+  const { mana, plantState } = useAppState();
+
   return (
     <SafeAreaView style={styles.container}>
-      <HomeScreenHeader
-        userName="Jugador"
-        manaCount={50}
-        plantState="Floreciendo"
-      />
+      <HomeScreenHeader userName="Jugador" manaCount={mana} plantState={plantState} />
       <ScrollView
         contentContainerStyle={{
           paddingHorizontal: Spacing.base,

--- a/src/state/AppContext.js
+++ b/src/state/AppContext.js
@@ -1,0 +1,50 @@
+// [MB] Módulo: Estado / Archivo: AppContext
+// Afecta: toda la app
+// Propósito: Proveer estado global para maná y estado de la planta
+// Puntos de edición futura: persistencia con AsyncStorage
+// Autor: Codex - Fecha: 2025-08-12
+
+import React, { createContext, useContext, useReducer } from "react";
+
+const AppStateContext = createContext();
+const AppDispatchContext = createContext();
+
+const initialState = { mana: 50, plantState: "Floreciendo" };
+
+function appReducer(state, action) {
+  switch (action.type) {
+    case "SET_MANA":
+      return { ...state, mana: action.payload };
+    case "SET_PLANT_STATE":
+      return { ...state, plantState: action.payload };
+    default:
+      return state;
+  }
+}
+
+export function AppProvider({ children }) {
+  const [state, dispatch] = useReducer(appReducer, initialState);
+  return (
+    <AppStateContext.Provider value={state}>
+      <AppDispatchContext.Provider value={dispatch}>
+        {children}
+      </AppDispatchContext.Provider>
+    </AppStateContext.Provider>
+  );
+}
+
+export function useAppState() {
+  const context = useContext(AppStateContext);
+  if (context === undefined) {
+    throw new Error("useAppState must be used within an AppProvider");
+  }
+  return context;
+}
+
+export function useAppDispatch() {
+  const context = useContext(AppDispatchContext);
+  if (context === undefined) {
+    throw new Error("useAppDispatch must be used within an AppProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add AppContext with mana and plantState plus hooks
- wrap app with AppProvider
- read context in Home and MagicShopSection

## Testing
- `npm test`
- `npm run start` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689bb3e0b92c832789b4fd0385f6d52e