### PR TITLE
feat: display mana in shop header

### DIFF
--- a/src/components/home/MagicShopSection.js
+++ b/src/components/home/MagicShopSection.js
@@ -1,4 +1,4 @@
-// [MB] Módulo: Home / Componente: MagicShopSection
+// [MB] Módulo: Home / Sección: Tienda Mágica (Pestañas)
 // Afecta: HomeScreen
 // Propósito: Sección de tienda mágica con tabs y maná disponible
 // Puntos de edición futura: integrar productos y navegación
@@ -6,6 +6,7 @@
 
 import React, { useState } from "react";
 import { View, Text, Pressable } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
 import styles from "./MagicShopSection.styles";
 import ShopItemCard from "./ShopItemCard";
 import { ShopColors } from "../../theme";
@@ -38,7 +39,25 @@ export default function MagicShopSection() {
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Tienda Mágica</Text>
-      <Text style={styles.manaText}>Maná disponible: {mana}</Text>
+
+      <View style={styles.manaRow}>
+        <Text style={styles.manaLabel} accessibilityRole="text">
+          Maná disponible
+        </Text>
+        <View
+          accessible
+          accessibilityLabel={`Maná disponible: ${mana}`}
+          style={[styles.manaPill, { borderColor: ShopColors[activeTab].pill }]}
+        >
+          <Ionicons
+            name="sparkles"
+            size={16}
+            color={ShopColors[activeTab].pill}
+            style={styles.manaIcon}
+          />
+          <Text style={styles.manaValue}>{mana}</Text>
+        </View>
+      </View>
 
       <View style={styles.tabsRow}>
         {TABS.map((tab, index) => {

--- a/src/components/home/MagicShopSection.styles.js
+++ b/src/components/home/MagicShopSection.styles.js
@@ -1,4 +1,4 @@
-// [MB] Módulo: Home / Estilos: MagicShopSection
+// [MB] Módulo: Home / Sección: Tienda Mágica (Estilos)
 // Afecta: HomeScreen
 // Propósito: Estilos para sección de tienda mágica con tabs y cards
 // Puntos de edición futura: diferenciar categorías y tarjetas
@@ -25,14 +25,35 @@ export default StyleSheet.create({
     ...Typography.h2,
     color: Colors.text,
   },
-  manaText: {
+  manaRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginTop: Spacing.small,
+    paddingVertical: Spacing.small,
+    marginBottom: Spacing.base,
+  },
+  manaLabel: {
     ...Typography.caption,
     color: Colors.text,
-    marginTop: Spacing.small,
+  },
+  manaPill: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderWidth: 1,
+    borderRadius: Radii.pill,
+    paddingHorizontal: Spacing.base,
+    height: 28,
+  },
+  manaIcon: {
+    marginRight: Spacing.tiny,
+  },
+  manaValue: {
+    ...Typography.body,
+    color: Colors.text,
   },
   tabsRow: {
     flexDirection: "row",
-    marginTop: Spacing.base,
   },
   tabButton: {
     flex: 1,


### PR DESCRIPTION
## Summary
- show available mana with label and pill in MagicShopSection
- style mana header row with theme tokens and accessible labels

## Testing
- `npm test`
- `npm run web` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689bb5661f2c83279b2eb3104a18bcfa