### PR TITLE
feat: add daily reward with streak persistence

### DIFF
--- a/src/components/home/DailyRewardSection.js
+++ b/src/components/home/DailyRewardSection.js
@@ -1,0 +1,48 @@
+// [MB] Módulo: Home / Sección: Recompensa Diaria
+// Afecta: HomeScreen
+// Propósito: Mostrar botón para reclamar recompensa diaria
+// Puntos de edición futura: integrar animaciones y estados visuales
+// Autor: Codex - Fecha: 2025-08-12
+
+import React from "react";
+import { View, Text, Pressable } from "react-native";
+import styles from "./DailyRewardSection.styles";
+import {
+  useAppDispatch,
+  useAppState,
+  useCanClaimToday,
+  DAILY_REWARD_MANA,
+} from "../../state/AppContext";
+
+export default function DailyRewardSection() {
+  const dispatch = useAppDispatch();
+  const { streak } = useAppState();
+  const canClaimToday = useCanClaimToday();
+
+  const handleClaim = () => {
+    dispatch({ type: "CLAIM_DAILY_REWARD" });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Recompensa diaria</Text>
+      {canClaimToday ? (
+        <Pressable
+          onPress={handleClaim}
+          style={styles.claimButton}
+          accessibilityRole="button"
+          accessibilityLabel="Reclamar recompensa diaria"
+        >
+          <Text style={styles.claimButtonText}>
+            {`Reclamar recompensa diaria (+${DAILY_REWARD_MANA})`}
+          </Text>
+        </Pressable>
+      ) : (
+        <View>
+          <Text style={styles.claimedText}>Ya reclamaste hoy</Text>
+          <Text style={styles.streakText}>{`Racha: ${streak} días`}</Text>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/src/components/home/DailyRewardSection.styles.js
+++ b/src/components/home/DailyRewardSection.styles.js
@@ -1,0 +1,49 @@
+// [MB] Módulo: Home / Estilos: Recompensa Diaria
+// Afecta: HomeScreen
+// Propósito: Estilos para sección de recompensa diaria
+// Puntos de edición futura: ajustar colores y diseño del botón
+// Autor: Codex - Fecha: 2025-08-12
+
+import { StyleSheet } from "react-native";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Elevation,
+  Typography,
+} from "../../theme";
+
+export default StyleSheet.create({
+  container: {
+    backgroundColor: Colors.surface,
+    padding: Spacing.base,
+    borderRadius: Radii.lg,
+    marginBottom: Spacing.large,
+    ...Elevation.card,
+  },
+  title: {
+    ...Typography.title,
+    color: Colors.text,
+    marginBottom: Spacing.small,
+  },
+  claimButton: {
+    backgroundColor: Colors.buttonBg,
+    paddingVertical: Spacing.small,
+    paddingHorizontal: Spacing.base,
+    borderRadius: Radii.md,
+    alignItems: "center",
+  },
+  claimButtonText: {
+    ...Typography.body,
+    color: Colors.textInverse,
+  },
+  claimedText: {
+    ...Typography.body,
+    color: Colors.text,
+    marginBottom: Spacing.small,
+  },
+  streakText: {
+    ...Typography.caption,
+    color: Colors.textMuted,
+  },
+});

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -10,6 +10,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { Colors, Spacing } from "../theme";
 import HomeScreenHeader from "../components/HomeScreenHeader";
 import HomeWelcomeCard from "../components/home/HomeWelcomeCard";
+import DailyRewardSection from "../components/home/DailyRewardSection";
 import DailyChallengesSection from "../components/home/DailyChallengesSection";
 import MagicShopSection from "../components/home/MagicShopSection";
 import NewsFeedSection from "../components/home/NewsFeedSection";
@@ -30,6 +31,7 @@ export default function HomeScreen() {
         }}
       >
         <HomeWelcomeCard />
+        <DailyRewardSection />
         <DailyChallengesSection />
         <MagicShopSection />
         <NewsFeedSection />

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,12 +1,14 @@
 // [MB] Módulo: Estado / Sección: Storage helpers
-// Afecta: AppContext (persistencia de maná)
-// Propósito: Persistir maná en AsyncStorage
+// Afecta: AppContext (persistencia de maná y rachas)
+// Propósito: Persistir datos básicos de usuario en AsyncStorage
 // Puntos de edición futura: extender a otros campos y manejo de errores
 // Autor: Codex - Fecha: 2025-08-12
 
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const MANA_KEY = "mb:mana";
+const STREAK_KEY = "mb:streak";
+const LAST_CLAIM_DATE_KEY = "mb:lastClaimDate";
 
 export async function getMana() {
   try {
@@ -26,6 +28,45 @@ export async function setMana(value) {
     await AsyncStorage.setItem(MANA_KEY, String(value));
   } catch (e) {
     console.warn("Error guardando maná en storage", e);
+  }
+}
+
+export async function getStreak() {
+  try {
+    const value = await AsyncStorage.getItem(STREAK_KEY);
+    if (value !== null) {
+      const parsed = Number(value);
+      return Number.isNaN(parsed) ? 0 : parsed;
+    }
+  } catch (e) {
+    console.warn("Error leyendo racha de storage", e);
+  }
+  return 0;
+}
+
+export async function setStreak(value) {
+  try {
+    await AsyncStorage.setItem(STREAK_KEY, String(value));
+  } catch (e) {
+    console.warn("Error guardando racha en storage", e);
+  }
+}
+
+export async function getLastClaimDate() {
+  try {
+    const value = await AsyncStorage.getItem(LAST_CLAIM_DATE_KEY);
+    return value ?? null;
+  } catch (e) {
+    console.warn("Error leyendo fecha de reclamo de storage", e);
+    return null;
+  }
+}
+
+export async function setLastClaimDate(value) {
+  try {
+    await AsyncStorage.setItem(LAST_CLAIM_DATE_KEY, value);
+  } catch (e) {
+    console.warn("Error guardando fecha de reclamo en storage", e);
   }
 }
 


### PR DESCRIPTION
## Summary
- persist daily streak and last claim date in AsyncStorage
- add daily reward logic with streak handling in AppContext
- display daily reward UI on home screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bb82acde08327835954127de15989