### PR TITLE
feat(shop): compra de ítems con descuento de maná y feedback

### DIFF
--- a/src/components/home/MagicShopSection.js
+++ b/src/components/home/MagicShopSection.js
@@ -5,12 +5,12 @@
 // Autor: Codex - Fecha: 2025-08-12
 
 import React, { useState } from "react";
-import { View, Text, Pressable } from "react-native";
+import { View, Text, Pressable, Alert } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import styles from "./MagicShopSection.styles";
 import ShopItemCard from "./ShopItemCard";
 import { ShopColors } from "../../theme";
-import { useAppState, useAppDispatch } from "../../state/AppContext";
+import { useAppState, useAppDispatch, useCanAfford } from "../../state/AppContext";
 
 const TABS = [
   { key: "potions", label: "Pociones" },
@@ -36,6 +36,7 @@ export default function MagicShopSection() {
   const [activeTab, setActiveTab] = useState("potions");
   const { mana } = useAppState();
   const dispatch = useAppDispatch();
+  const canAfford = useCanAfford();
 
   const addDebugMana = () =>
     dispatch({ type: "SET_MANA", payload: mana + 5 });
@@ -96,18 +97,30 @@ export default function MagicShopSection() {
         })}
       </View>
 
-      {SHOP_ITEMS[activeTab].map((item) => (
-        <View key={item.id} style={styles.itemWrapper}>
-          <ShopItemCard
-            title={item.title}
-            description={item.description}
-            price={item.price}
-            iconName={item.iconName}
-            accent={ShopColors[activeTab]}
-            accessibilityLabel={`Comprar ${item.title} por ${item.price} maná`}
-          />
-        </View>
-      ))}
+      {SHOP_ITEMS[activeTab].map((item) => {
+        const affordable = canAfford(item.price);
+        return (
+          <View key={item.id} style={styles.itemWrapper}>
+            <ShopItemCard
+              title={item.title}
+              description={item.description}
+              price={item.price}
+              iconName={item.iconName}
+              accent={ShopColors[activeTab]}
+              disabled={!affordable}
+              onPress={() => {
+                if (canAfford(item.price)) {
+                  dispatch({ type: "PURCHASE_WITH_MANA", payload: item.price });
+                  Alert.alert("Compra exitosa", "¡Comprado!");
+                } else {
+                  Alert.alert("Sin maná", "Maná insuficiente");
+                }
+              }}
+              accessibilityLabel={`Comprar ${item.title} por ${item.price} maná`}
+            />
+          </View>
+        );
+      })}
 
       <Pressable
         style={styles.viewAllButton}

--- a/src/components/home/ShopItemCard.js
+++ b/src/components/home/ShopItemCard.js
@@ -8,7 +8,7 @@ import React from "react";
 import { Pressable, View, Text } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import styles from "./ShopItemCard.styles";
-import { Colors } from "../../theme";
+import { Colors, Opacity } from "../../theme";
 
 export default function ShopItemCard({
   title,
@@ -17,25 +17,34 @@ export default function ShopItemCard({
   iconName,
   accent,
   selected,
+  disabled,
   onPress,
   ...rest
 }) {
   return (
     <Pressable
       onPress={onPress}
+      disabled={disabled}
       style={[
         styles.card,
         { borderColor: accent.border },
-        selected && { borderColor: accent.pill, shadowColor: accent.pill },
+        selected && {
+          borderColor: accent.pill,
+          shadowColor: accent.pill,
+          shadowOpacity: 0.6,
+          shadowRadius: 6,
+        },
+        disabled && { opacity: Opacity.disabled },
       ]}
       accessibilityRole="button"
+      accessibilityState={{ disabled }}
       {...rest}
     >
       <View style={styles.info}>
         <Text style={styles.title}>{title}</Text>
         <Text style={styles.description}>{description}</Text>
       </View>
-      <View style={[styles.pill, { backgroundColor: accent.pill }]}>
+      <View style={[styles.pill, { backgroundColor: accent.pill }]}> 
         <Ionicons name={iconName} size={16} color={Colors.textInverse} />
         <Text style={styles.pillText}>{price}</Text>
       </View>

--- a/src/state/AppContext.js
+++ b/src/state/AppContext.js
@@ -10,6 +10,7 @@ import React, {
   useReducer,
   useEffect,
   useRef,
+  useCallback,
 } from "react";
 import {
   getMana,
@@ -59,6 +60,13 @@ function appReducer(state, action) {
         streak: newStreak,
         lastClaimDate: today,
       };
+    }
+    case "PURCHASE_WITH_MANA": {
+      const cost = action.payload;
+      if (state.mana < cost) {
+        return state;
+      }
+      return { ...state, mana: state.mana - cost };
     }
     default:
       return state;
@@ -129,4 +137,9 @@ export function useAppDispatch() {
 export function useCanClaimToday() {
   const { lastClaimDate } = useAppState();
   return lastClaimDate !== getLocalISODate();
+}
+
+export function useCanAfford() {
+  const { mana } = useAppState();
+  return useCallback((cost) => mana >= cost, [mana]);
 }


### PR DESCRIPTION
## Summary
- add PURCHASE_WITH_MANA reducer action and can-afford selector
- wire MagicShopSection cards to purchase with mana and show alerts
- support disabled/selected states in ShopItemCard styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bb9a729b083278b0d792f4c119913