### PR TITLE
feat(inventory): inventario persistente y resumen en Home

### DIFF
--- a/src/components/home/InventorySection.js
+++ b/src/components/home/InventorySection.js
@@ -1,0 +1,50 @@
+// [MB] Módulo: Home / Sección: Inventario
+// Afecta: HomeScreen
+// Propósito: Resumen de inventario con conteos y lista corta
+// Puntos de edición futura: navegación a inventario completo
+// Autor: Codex - Fecha: 2025-08-12
+
+import React from "react";
+import { View, Text, Pressable } from "react-native";
+import styles from "./InventorySection.styles";
+import { useAppState, useInventoryCounts } from "../../state/AppContext";
+
+export default function InventorySection() {
+  const { inventory } = useAppState();
+  const counts = useInventoryCounts();
+  const topItems = inventory.slice(0, 3);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Inventario</Text>
+
+      <View style={styles.chipsRow}>
+        <View style={styles.chip}>
+          <Text style={styles.chipText}>Pociones {counts.potions}</Text>
+        </View>
+        <View style={styles.chip}>
+          <Text style={styles.chipText}>Herramientas {counts.tools}</Text>
+        </View>
+        <View style={styles.chip}>
+          <Text style={styles.chipText}>Cosméticos {counts.cosmetics}</Text>
+        </View>
+      </View>
+
+      <View style={styles.list}>
+        {topItems.map((item) => (
+          <View key={item.id} style={styles.itemCard}>
+            <Text style={styles.itemText}>{`${item.title} × ${item.quantity}`}</Text>
+          </View>
+        ))}
+      </View>
+
+      <Pressable
+        style={styles.viewAllButton}
+        accessibilityRole="button"
+        accessibilityLabel="Ver inventario completo"
+      >
+        <Text style={styles.viewAllText}>Ver todo</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/src/components/home/InventorySection.styles.js
+++ b/src/components/home/InventorySection.styles.js
@@ -1,0 +1,70 @@
+// [MB] Módulo: Home / Sección: Inventario (Estilos)
+// Afecta: HomeScreen
+// Propósito: Estilos para resumen de inventario
+// Puntos de edición futura: colores por categoría y lista completa
+// Autor: Codex - Fecha: 2025-08-12
+
+import { StyleSheet } from "react-native";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Typography,
+  Elevation,
+} from "../../theme";
+
+export default StyleSheet.create({
+  container: {
+    backgroundColor: Colors.surface,
+    padding: Spacing.base,
+    borderRadius: Radii.md,
+    marginBottom: Spacing.large,
+    ...Elevation.card,
+  },
+  title: {
+    ...Typography.h2,
+    color: Colors.text,
+  },
+  chipsRow: {
+    flexDirection: "row",
+    marginTop: Spacing.small,
+  },
+  chip: {
+    backgroundColor: Colors.surfaceElevated,
+    borderRadius: Radii.pill,
+    paddingHorizontal: Spacing.base,
+    height: 28,
+    justifyContent: "center",
+    marginRight: Spacing.small,
+  },
+  chipText: {
+    ...Typography.caption,
+    color: Colors.text,
+  },
+  list: {
+    marginTop: Spacing.base,
+  },
+  itemCard: {
+    backgroundColor: Colors.surfaceElevated,
+    borderRadius: Radii.lg,
+    padding: Spacing.small,
+    marginBottom: Spacing.small,
+    ...Elevation.card,
+  },
+  itemText: {
+    ...Typography.body,
+    color: Colors.text,
+  },
+  viewAllButton: {
+    marginTop: Spacing.base,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: Radii.md,
+    paddingVertical: Spacing.small,
+    alignItems: "center",
+  },
+  viewAllText: {
+    ...Typography.body,
+    color: Colors.text,
+  },
+});

--- a/src/components/home/MagicShopSection.js
+++ b/src/components/home/MagicShopSection.js
@@ -111,7 +111,15 @@ export default function MagicShopSection() {
               onPress={() => {
                 if (canAfford(item.price)) {
                   dispatch({ type: "PURCHASE_WITH_MANA", payload: item.price });
-                  Alert.alert("Compra exitosa", "¡Comprado!");
+                  dispatch({
+                    type: "ADD_TO_INVENTORY",
+                    payload: {
+                      sku: `shop/${activeTab}/${item.id}`,
+                      title: item.title,
+                      category: activeTab,
+                    },
+                  });
+                  Alert.alert("Compra exitosa — añadido al inventario");
                 } else {
                   Alert.alert("Sin maná", "Maná insuficiente");
                 }

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -13,6 +13,7 @@ import HomeWelcomeCard from "../components/home/HomeWelcomeCard";
 import DailyRewardSection from "../components/home/DailyRewardSection";
 import DailyChallengesSection from "../components/home/DailyChallengesSection";
 import MagicShopSection from "../components/home/MagicShopSection";
+import InventorySection from "../components/home/InventorySection";
 import NewsFeedSection from "../components/home/NewsFeedSection";
 import StatsQuickTiles from "../components/home/StatsQuickTiles";
 import EventBanner from "../components/home/EventBanner";
@@ -34,6 +35,7 @@ export default function HomeScreen() {
         <DailyRewardSection />
         <DailyChallengesSection />
         <MagicShopSection />
+        <InventorySection />
         <NewsFeedSection />
         <StatsQuickTiles />
         <EventBanner />

--- a/src/storage.js
+++ b/src/storage.js
@@ -11,6 +11,7 @@ const STREAK_KEY = "mb:streak";
 const LAST_CLAIM_DATE_KEY = "mb:lastClaimDate";
 const PROGRESS_KEY = "mb:progress";
 const TASKS_KEY = "mb:tasks";
+const INVENTORY_KEY = "mb:inventory";
 
 export async function getMana() {
   try {
@@ -112,6 +113,25 @@ export async function setTasks(tasks) {
     await AsyncStorage.setItem(TASKS_KEY, JSON.stringify(tasks));
   } catch (e) {
     console.warn("Error guardando tareas en storage", e);
+  }
+}
+
+// [MB] Helpers de inventario
+export async function getInventory() {
+  try {
+    const value = await AsyncStorage.getItem(INVENTORY_KEY);
+    return value ? JSON.parse(value) : [];
+  } catch (e) {
+    console.warn("Error leyendo inventario de storage", e);
+    return [];
+  }
+}
+
+export async function setInventory(items) {
+  try {
+    await AsyncStorage.setItem(INVENTORY_KEY, JSON.stringify(items));
+  } catch (e) {
+    console.warn("Error guardando inventario en storage", e);
   }
 }
 


### PR DESCRIPTION
## Summary
- storage: add inventory helpers to persist items
- AppContext: state, hydration and ADD_TO_INVENTORY action
- MagicShop: purchases now append to inventory
- Home: new InventorySection shows counts and recent items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bbf86c3048327b5e8ab8111382f41