### PR TITLE
feat: consume Mana Crystal potion from inventory

### DIFF
--- a/src/components/home/InventorySection.js
+++ b/src/components/home/InventorySection.js
@@ -5,14 +5,25 @@
 // Autor: Codex - Fecha: 2025-08-12
 
 import React from "react";
-import { View, Text, Pressable } from "react-native";
+import { View, Text, Pressable, Alert } from "react-native";
 import styles from "./InventorySection.styles";
-import { useAppState, useInventoryCounts } from "../../state/AppContext";
+import {
+  useAppState,
+  useAppDispatch,
+  useInventoryCounts,
+} from "../../state/AppContext";
+import { Opacity } from "../../theme";
 
 export default function InventorySection() {
   const { inventory } = useAppState();
+  const dispatch = useAppDispatch();
   const counts = useInventoryCounts();
   const topItems = inventory.slice(0, 3);
+
+  const handleUse = (item) => {
+    dispatch({ type: "CONSUME_ITEM", payload: { sku: item.sku } });
+    Alert.alert("Poción usada", "Cristal de Maná +100");
+  };
 
   return (
     <View style={styles.container}>
@@ -31,11 +42,31 @@ export default function InventorySection() {
       </View>
 
       <View style={styles.list}>
-        {topItems.map((item) => (
-          <View key={item.id} style={styles.itemCard}>
-            <Text style={styles.itemText}>{`${item.title} × ${item.quantity}`}</Text>
-          </View>
-        ))}
+        {topItems.map((item) => {
+          const isUsable =
+            item.category === "potions" &&
+            item.quantity > 0 &&
+            item.sku === "shop/potions/p2";
+          return (
+            <View key={item.id} style={styles.itemCard}>
+              <Text style={styles.itemText}>{`${item.title} × ${item.quantity}`}</Text>
+              <Pressable
+                onPress={() => handleUse(item)}
+                disabled={!isUsable}
+                style={[
+                  styles.useButton,
+                  !isUsable && { opacity: Opacity.disabled },
+                ]}
+                accessibilityRole="button"
+                accessibilityLabel={`${isUsable ? "Usar" : "No usable"} ${item.title}`}
+              >
+                <Text style={styles.useButtonText}>
+                  {isUsable ? "Usar" : "No usable"}
+                </Text>
+              </Pressable>
+            </View>
+          );
+        })}
       </View>
 
       <Pressable

--- a/src/components/home/InventorySection.styles.js
+++ b/src/components/home/InventorySection.styles.js
@@ -49,11 +49,25 @@ export default StyleSheet.create({
     borderRadius: Radii.lg,
     padding: Spacing.small,
     marginBottom: Spacing.small,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
     ...Elevation.card,
   },
   itemText: {
     ...Typography.body,
     color: Colors.text,
+  },
+  useButton: {
+    backgroundColor: Colors.buttonBg,
+    paddingVertical: Spacing.tiny,
+    paddingHorizontal: Spacing.small,
+    borderRadius: Radii.sm,
+    marginLeft: Spacing.small,
+  },
+  useButtonText: {
+    ...Typography.caption,
+    color: Colors.textInverse,
   },
   viewAllButton: {
     marginTop: Spacing.base,

--- a/src/components/home/MagicShopSection.js
+++ b/src/components/home/MagicShopSection.js
@@ -44,6 +44,7 @@ export default function MagicShopSection() {
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Tienda Mágica</Text>
+      <Text style={styles.subtitle}>Las pociones compradas se guardan en Inventario</Text>
 
       <View style={styles.manaRow}>
         <Text style={styles.manaLabel} accessibilityRole="text">

--- a/src/components/home/MagicShopSection.styles.js
+++ b/src/components/home/MagicShopSection.styles.js
@@ -25,6 +25,11 @@ export default StyleSheet.create({
     ...Typography.h2,
     color: Colors.text,
   },
+  subtitle: {
+    ...Typography.caption,
+    color: Colors.textMuted,
+    marginTop: Spacing.tiny,
+  },
   manaRow: {
     flexDirection: "row",
     alignItems: "center",

--- a/src/state/AppContext.js
+++ b/src/state/AppContext.js
@@ -124,6 +124,23 @@ function appReducer(state, action) {
       }
       return { ...state, mana: state.mana - cost };
     }
+    case "CONSUME_ITEM": {
+      const { sku } = action.payload;
+      const item = state.inventory.find((it) => it.sku === sku);
+      if (!item || item.quantity <= 0) {
+        return state;
+      }
+      let mana = state.mana;
+      if (sku === "shop/potions/p2") {
+        mana += 100;
+      }
+      const inventory = state.inventory
+        .map((it) =>
+          it.sku === sku ? { ...it, quantity: it.quantity - 1 } : it
+        )
+        .filter((it) => it.quantity > 0);
+      return { ...state, mana, inventory };
+    }
     default:
       return state;
   }


### PR DESCRIPTION
## Summary
- add CONSUME_ITEM action to reducer, granting +100 mana for Mana Crystal potion
- enable "Usar" button in inventory list for consumable potions
- note in Magic Shop about purchased potions being stored in inventory

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bc143c5348327ad48470d4bd02e8e