### PR TITLE
feat(buffs): Poción de Sabiduría (XP×2 por 2h) con persistencia

### DIFF
--- a/src/components/StatsHeader.js
+++ b/src/components/StatsHeader.js
@@ -7,12 +7,21 @@
 import React from "react";
 import { View, Text, StyleSheet, Platform, StatusBar } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
-import { Colors, Spacing } from "../theme";
-import { useProgress, useAppState } from "../state/AppContext";
+import { Colors, Spacing, Radii, Typography } from "../theme";
+import { useProgress, useAppState, useXpMultiplier } from "../state/AppContext";
 
 export default function StatsHeader() {
   const { level, xp, xpGoal, progress } = useProgress();
   const { mana } = useAppState();
+  const { multiplier, expiresAt } = useXpMultiplier();
+  const remainingMs = expiresAt ? expiresAt - Date.now() : 0;
+  const formatRemaining = (ms) => {
+    const total = Math.max(0, Math.floor(ms / 60000));
+    const h = Math.floor(total / 60);
+    const m = total % 60;
+    return `${h}h ${m}m`;
+  };
+  const remainingText = expiresAt ? formatRemaining(remainingMs) : null;
   const percent = Math.min(Math.max(progress * 100, 0), 100);
   return (
     <View style={styles.container}>
@@ -23,7 +32,19 @@ export default function StatsHeader() {
             {xp}/{xpGoal} XP
           </Text>
         </View>
-        <Text style={styles.manaText}>Vida: {mana}</Text>
+        <View style={styles.rightRow}>
+          {multiplier === 2 && (
+            <View style={styles.buffContainer}>
+              <View style={styles.buffChip}>
+                <Text style={styles.buffChipText}>XP×2</Text>
+              </View>
+              {remainingText && (
+                <Text style={styles.buffTime}>{remainingText}</Text>
+              )}
+            </View>
+          )}
+          <Text style={styles.manaText}>Vida: {mana}</Text>
+        </View>
       </View>
       <View style={styles.progressBackground}>
         <LinearGradient
@@ -73,6 +94,31 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: Colors.text,
     fontWeight: "600",
+  },
+  rightRow: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  buffContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginRight: Spacing.small,
+  },
+  buffChip: {
+    backgroundColor: Colors.accent,
+    borderRadius: Radii.pill,
+    paddingHorizontal: Spacing.small,
+    height: 24,
+    justifyContent: "center",
+    marginRight: Spacing.tiny,
+  },
+  buffChipText: {
+    ...Typography.caption,
+    color: Colors.textInverse,
+  },
+  buffTime: {
+    ...Typography.caption,
+    color: Colors.text,
   },
   progressBackground: {
     width: "100%",

--- a/src/components/home/InventorySection.js
+++ b/src/components/home/InventorySection.js
@@ -21,8 +21,21 @@ export default function InventorySection() {
   const topItems = inventory.slice(0, 3);
 
   const handleUse = (item) => {
+    const current = inventory.find((it) => it.sku === item.sku);
+    if (!current || current.quantity <= 0) return;
     dispatch({ type: "CONSUME_ITEM", payload: { sku: item.sku } });
-    Alert.alert("Poción usada", "Cristal de Maná +100");
+    if (item.sku === "shop/potions/p1") {
+      dispatch({
+        type: "ACTIVATE_BUFF",
+        payload: { type: "xp_double", durationMs: 2 * 60 * 60 * 1000 },
+      });
+      Alert.alert(
+        "Poción usada",
+        "Sabiduría activa: XP x2 por 2 horas"
+      );
+    } else if (item.sku === "shop/potions/p2") {
+      Alert.alert("Poción usada", "Cristal de Maná +100");
+    }
   };
 
   return (
@@ -46,7 +59,7 @@ export default function InventorySection() {
           const isUsable =
             item.category === "potions" &&
             item.quantity > 0 &&
-            item.sku === "shop/potions/p2";
+            (item.sku === "shop/potions/p2" || item.sku === "shop/potions/p1");
           return (
             <View key={item.id} style={styles.itemCard}>
               <Text style={styles.itemText}>{`${item.title} × ${item.quantity}`}</Text>

--- a/src/storage.js
+++ b/src/storage.js
@@ -135,3 +135,24 @@ export async function setInventory(items) {
   }
 }
 
+// [MB] Helpers de buffs
+const BUFFS_KEY = "mb:buffs";
+
+export async function getBuffs() {
+  try {
+    const value = await AsyncStorage.getItem(BUFFS_KEY);
+    return value ? JSON.parse(value) : [];
+  } catch (e) {
+    console.warn("Error leyendo buffs de storage", e);
+    return [];
+  }
+}
+
+export async function setBuffs(buffs) {
+  try {
+    await AsyncStorage.setItem(BUFFS_KEY, JSON.stringify(buffs));
+  } catch (e) {
+    console.warn("Error guardando buffs en storage", e);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add storage helpers for buffs
- extend AppContext with buffs, actions and XP multiplier logic
- allow using Poción de Sabiduría to activate XP×2 buff and show chip with remaining time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bc2f8ebd4832783f98bc882ea3de3