### PR TITLE
feat(challenges): desafíos diarios con progreso, reclamo y reinicio por día

### DIFF
--- a/src/components/home/DailyChallengesSection.js
+++ b/src/components/home/DailyChallengesSection.js
@@ -1,17 +1,71 @@
 // [MB] Módulo: Home / Componente: DailyChallengesSection
 // Afecta: HomeScreen
-// Propósito: Sección placeholder para desafíos diarios
-// Puntos de edición futura: añadir lista de desafíos y acciones
+// Propósito: Mostrar desafíos diarios con progreso y reclamo de recompensas
+// Puntos de edición futura: animaciones y estados avanzados
 // Autor: Codex - Fecha: 2025-08-12
 
 import React from "react";
-import { View, Text } from "react-native";
+import { View, Text, Pressable } from "react-native";
 import styles from "./DailyChallengesSection.styles";
+import { useDailyChallenges, useAppDispatch } from "../../state/AppContext";
 
 export default function DailyChallengesSection() {
+  const dispatch = useAppDispatch();
+  const { items } = useDailyChallenges();
+
+  const handleClaim = (id) => {
+    dispatch({ type: "CLAIM_DAILY_CHALLENGE", payload: { id } });
+  };
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Desafíos Diarios</Text>
+      {items.map((item) => {
+        const canClaim = item.progress >= item.goal && !item.claimed;
+        const buttonLabel = canClaim
+          ? "Reclamar"
+          : item.claimed
+          ? "Reclamado"
+          : "En progreso";
+        return (
+          <View key={item.id} style={styles.card}>
+            <View style={styles.headerRow}>
+              <Text style={styles.challengeTitle}>{item.title}</Text>
+              <View style={styles.rewardPill}>
+                <Text style={styles.rewardText}>{`+${item.reward.xp} XP / +${item.reward.mana} Maná`}</Text>
+              </View>
+            </View>
+            <View style={styles.progressBar}>
+              <View
+                style={[
+                  styles.progressFill,
+                  { width: `${(item.progress / item.goal) * 100}%` },
+                ]}
+              />
+            </View>
+            <Text style={styles.progressText}>{`${item.progress}/${item.goal}`}</Text>
+            <Pressable
+              onPress={() => handleClaim(item.id)}
+              disabled={!canClaim}
+              style={[
+                styles.claimButton,
+                canClaim ? styles.claimButtonEnabled : styles.claimButtonDisabled,
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={`${buttonLabel} desafío ${item.title}`}
+            >
+              <Text
+                style={[
+                  styles.claimButtonText,
+                  !canClaim && styles.claimButtonTextDisabled,
+                ]}
+              >
+                {buttonLabel}
+              </Text>
+            </Pressable>
+          </View>
+        );
+      })}
     </View>
   );
 }

--- a/src/components/home/DailyChallengesSection.styles.js
+++ b/src/components/home/DailyChallengesSection.styles.js
@@ -1,7 +1,7 @@
 // [MB] Módulo: Home / Estilos: DailyChallengesSection
 // Afecta: HomeScreen
-// Propósito: Estilos placeholder para la sección de desafíos diarios
-// Puntos de edición futura: manejar lista dinámica y estados
+// Propósito: Estilos para desafíos diarios con progreso y botones
+// Puntos de edición futura: ajustar barra de progreso y botones
 // Autor: Codex - Fecha: 2025-08-12
 
 import { StyleSheet } from "react-native";
@@ -24,5 +24,68 @@ export default StyleSheet.create({
   title: {
     ...Typography.h2,
     color: Colors.text,
+  },
+  card: {
+    backgroundColor: Colors.surfaceAlt,
+    padding: Spacing.base,
+    borderRadius: Radii.md,
+    marginTop: Spacing.base,
+  },
+  headerRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: Spacing.small,
+  },
+  challengeTitle: {
+    ...Typography.body,
+    color: Colors.text,
+    flex: 1,
+    marginRight: Spacing.small,
+  },
+  rewardPill: {
+    backgroundColor: Colors.filterBtnBg,
+    borderRadius: Radii.pill,
+    paddingHorizontal: Spacing.small,
+    paddingVertical: Spacing.tiny,
+  },
+  rewardText: {
+    ...Typography.caption,
+    color: Colors.text,
+  },
+  progressBar: {
+    height: 6,
+    backgroundColor: Colors.border,
+    borderRadius: Radii.pill,
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    backgroundColor: Colors.secondary,
+    borderRadius: Radii.pill,
+  },
+  progressText: {
+    ...Typography.caption,
+    color: Colors.textMuted,
+    marginTop: Spacing.tiny,
+  },
+  claimButton: {
+    marginTop: Spacing.small,
+    paddingVertical: Spacing.small,
+    borderRadius: Radii.md,
+    alignItems: "center",
+  },
+  claimButtonEnabled: {
+    backgroundColor: Colors.buttonBg,
+  },
+  claimButtonDisabled: {
+    backgroundColor: Colors.filterBtnBg,
+  },
+  claimButtonText: {
+    ...Typography.body,
+    color: Colors.textInverse,
+  },
+  claimButtonTextDisabled: {
+    color: Colors.textMuted,
   },
 });

--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -234,6 +234,10 @@ export default function TasksScreen() {
         type: "APPLY_TASK_REWARD",
         payload: { xpDelta: xp, manaDelta: mana },
       });
+      dispatch({
+        type: "UPDATE_DAILY_CHALLENGES_ON_TASK_DONE",
+        payload: { priority: priorityLabel },
+      });
     }
   };
 

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,5 +1,5 @@
 // [MB] Módulo: Estado / Sección: Storage helpers
-// Afecta: AppContext (persistencia de maná, rachas, progreso y tareas)
+// Afecta: AppContext (persistencia de maná, rachas, progreso, tareas y desafíos)
 // Propósito: Persistir datos básicos de usuario en AsyncStorage
 // Puntos de edición futura: extender a otros campos y manejo de errores
 // Autor: Codex - Fecha: 2025-08-12
@@ -12,6 +12,7 @@ const LAST_CLAIM_DATE_KEY = "mb:lastClaimDate";
 const PROGRESS_KEY = "mb:progress";
 const TASKS_KEY = "mb:tasks";
 const INVENTORY_KEY = "mb:inventory";
+const DAILY_CHALLENGES_KEY = "mb:dailyChallenges";
 
 export async function getMana() {
   try {
@@ -132,6 +133,25 @@ export async function setInventory(items) {
     await AsyncStorage.setItem(INVENTORY_KEY, JSON.stringify(items));
   } catch (e) {
     console.warn("Error guardando inventario en storage", e);
+  }
+}
+
+// [MB] Helpers de desafíos diarios
+export async function getDailyChallengesState() {
+  try {
+    const value = await AsyncStorage.getItem(DAILY_CHALLENGES_KEY);
+    return value ? JSON.parse(value) : null;
+  } catch (e) {
+    console.warn("Error leyendo desafíos diarios de storage", e);
+    return null;
+  }
+}
+
+export async function setDailyChallengesState(state) {
+  try {
+    await AsyncStorage.setItem(DAILY_CHALLENGES_KEY, JSON.stringify(state));
+  } catch (e) {
+    console.warn("Error guardando desafíos diarios en storage", e);
   }
 }
 


### PR DESCRIPTION
## Summary
- storage: helpers para estado persistente de desafíos diarios
- AppContext: genera/regenera desafíos, actualiza progreso y permite reclamar recompensas
- UI: sección DailyChallenges con barra de progreso y botón de reclamo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bc66316148327afdd4de9c0ae84aa