### PR TITLE
feat(news): add persistent NewsFeed with read markers

### DIFF
--- a/src/components/home/NewsFeedSection.js
+++ b/src/components/home/NewsFeedSection.js
@@ -1,17 +1,58 @@
 // [MB] Módulo: Home / Componente: NewsFeedSection
 // Afecta: HomeScreen
-// Propósito: Sección placeholder para noticias
-// Puntos de edición futura: conectar con feed real
+// Propósito: Mostrar noticias con marca de leído y persistencia
+// Puntos de edición futura: conectar con feed real y ajustar estilos
 // Autor: Codex - Fecha: 2025-08-12
 
 import React from "react";
-import { View, Text } from "react-native";
+import { View, Text, TouchableOpacity } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { Colors } from "../../theme";
 import styles from "./NewsFeedSection.styles";
+import { useNewsFeed, useAppDispatch } from "../../state/AppContext";
+
+function timeAgo(iso) {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(diffMs / 60000);
+  const h = Math.floor(m / 60);
+  const d = Math.floor(h / 24);
+  if (m < 60) return `hace ${m} min`;
+  if (h < 24) return `hace ${h} h`;
+  if (d === 1) return "ayer";
+  return `hace ${d} días`;
+}
 
 export default function NewsFeedSection() {
+  const { items } = useNewsFeed();
+  const dispatch = useAppDispatch();
+
+  const markAll = () => dispatch({ type: "MARK_ALL_NEWS_READ" });
+  const handlePress = (id) => {
+    dispatch({ type: "MARK_NEWS_READ", payload: { id } });
+  };
+
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Noticias</Text>
+      <View style={styles.header}>
+        <Text style={styles.title}>Noticias</Text>
+        <TouchableOpacity onPress={markAll}>
+          <Text style={styles.markAll}>Marcar todo como leído</Text>
+        </TouchableOpacity>
+      </View>
+      {items.map((item) => (
+        <TouchableOpacity
+          key={item.id}
+          style={styles.row}
+          onPress={() => handlePress(item.id)}
+        >
+          <Ionicons name={item.iconName} size={20} color={Colors.text} />
+          <View style={styles.rowText}>
+            <Text style={styles.rowTitle}>{item.title}</Text>
+            <Text style={styles.time}>{timeAgo(item.timestamp)}</Text>
+          </View>
+          {!item.read && <View style={styles.unreadDot} />}
+        </TouchableOpacity>
+      ))}
     </View>
   );
 }

--- a/src/components/home/NewsFeedSection.styles.js
+++ b/src/components/home/NewsFeedSection.styles.js
@@ -1,7 +1,7 @@
 // [MB] Módulo: Home / Estilos: NewsFeedSection
 // Afecta: HomeScreen
-// Propósito: Estilos placeholder para feed de noticias
-// Puntos de edición futura: manejar lista y tarjetas
+// Propósito: Estilos para feed de noticias con marcas de leído
+// Puntos de edición futura: ajustar layout y variantes de ítems
 // Autor: Codex - Fecha: 2025-08-12
 
 import { StyleSheet } from "react-native";
@@ -17,12 +17,43 @@ export default StyleSheet.create({
   container: {
     backgroundColor: Colors.surface,
     padding: Spacing.base,
-    borderRadius: Radii.md,
+    borderRadius: Radii.lg,
     marginBottom: Spacing.large,
     ...Elevation.card,
+    gap: Spacing.small,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
   },
   title: {
     ...Typography.h2,
     color: Colors.text,
+  },
+  markAll: {
+    ...Typography.caption,
+    color: Colors.accent,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.small,
+    paddingVertical: Spacing.small,
+  },
+  rowText: { flex: 1 },
+  rowTitle: {
+    ...Typography.body,
+    color: Colors.text,
+  },
+  time: {
+    ...Typography.caption,
+    color: Colors.textMuted,
+  },
+  unreadDot: {
+    width: 8,
+    height: 8,
+    borderRadius: Radii.pill,
+    backgroundColor: Colors.accent,
   },
 });

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,5 +1,5 @@
 // [MB] Módulo: Estado / Sección: Storage helpers
-// Afecta: AppContext (persistencia de maná, rachas, progreso, tareas y desafíos)
+// Afecta: AppContext (persistencia de maná, rachas, progreso, tareas, desafíos y noticias)
 // Propósito: Persistir datos básicos de usuario en AsyncStorage
 // Puntos de edición futura: extender a otros campos y manejo de errores
 // Autor: Codex - Fecha: 2025-08-12
@@ -13,6 +13,7 @@ const PROGRESS_KEY = "mb:progress";
 const TASKS_KEY = "mb:tasks";
 const INVENTORY_KEY = "mb:inventory";
 const DAILY_CHALLENGES_KEY = "mb:dailyChallenges";
+const NEWS_KEY = "mb:news";
 
 export async function getMana() {
   try {
@@ -173,6 +174,25 @@ export async function setBuffs(buffs) {
     await AsyncStorage.setItem(BUFFS_KEY, JSON.stringify(buffs));
   } catch (e) {
     console.warn("Error guardando buffs en storage", e);
+  }
+}
+
+// [MB] Helpers de noticias
+export async function getNewsFeed() {
+  try {
+    const value = await AsyncStorage.getItem(NEWS_KEY);
+    return value ? JSON.parse(value) : null;
+  } catch (e) {
+    console.warn("Error leyendo noticias de storage", e);
+    return null;
+  }
+}
+
+export async function setNewsFeed(feed) {
+  try {
+    await AsyncStorage.setItem(NEWS_KEY, JSON.stringify(feed));
+  } catch (e) {
+    console.warn("Error guardando noticias en storage", e);
   }
 }
 


### PR DESCRIPTION
## Summary
- add AsyncStorage helpers for NewsFeed
- hydrate NewsFeed in AppContext with mark read actions
- implement NewsFeedSection UI with relative time and mark-all button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bc868b9388327b642222592c1eb06