### PR TITLE
feat(home): connect StatsQuickTiles to context data

### DIFF
--- a/src/components/home/StatsQuickTiles.js
+++ b/src/components/home/StatsQuickTiles.js
@@ -1,26 +1,33 @@
 // [MB] Módulo: Home / Componente: StatsQuickTiles
 // Afecta: HomeScreen
-// Propósito: Contenedor placeholder para estadísticas rápidas
-// Puntos de edición futura: mostrar valores reales y gráficos
+// Propósito: Mostrar racha, nivel y maná desde el contexto
+// Puntos de edición futura: añadir más estadísticas o gráficos
 // Autor: Codex - Fecha: 2025-08-12
 
 import React from "react";
 import { View, Text } from "react-native";
 import styles from "./StatsQuickTiles.styles";
+import { useAppState, useProgress } from "../../state/AppContext";
 
 export default function StatsQuickTiles() {
+  const { streak, mana } = useAppState();
+  const { level } = useProgress();
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Estadísticas</Text>
       <View style={styles.tiles}>
         <View style={styles.tile}>
-          <Text style={styles.tileText}>Maná</Text>
+          <Text style={styles.tileValue}>{streak}</Text>
+          <Text style={styles.tileLabel}>Días de racha</Text>
         </View>
         <View style={styles.tile}>
-          <Text style={styles.tileText}>XP</Text>
+          <Text style={styles.tileValue}>{level}</Text>
+          <Text style={styles.tileLabel}>Nivel</Text>
         </View>
-        <View style={styles.tile}>
-          <Text style={styles.tileText}>Racha</Text>
+        <View style={[styles.tile, styles.tileSmall]}>
+          <Text style={styles.tileValue}>{mana}</Text>
+          <Text style={styles.tileLabel}>Maná</Text>
         </View>
       </View>
     </View>

--- a/src/components/home/StatsQuickTiles.styles.js
+++ b/src/components/home/StatsQuickTiles.styles.js
@@ -1,7 +1,7 @@
 // [MB] Módulo: Home / Estilos: StatsQuickTiles
 // Afecta: HomeScreen
-// Propósito: Estilos placeholder para estadísticas rápidas
-// Puntos de edición futura: ajustar layout de mosaicos
+// Propósito: Estilos para racha, nivel y maná en mosaicos
+// Puntos de edición futura: ajustar layout o añadir animaciones
 // Autor: Codex - Fecha: 2025-08-12
 
 import { StyleSheet } from "react-native";
@@ -39,7 +39,17 @@ export default StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
-  tileText: {
+  tileSmall: {
+    flex: 0,
+    width: Spacing.xlarge * 2,
+    marginHorizontal: 0,
+    marginLeft: Spacing.tiny,
+  },
+  tileValue: {
+    ...Typography.h2,
+    color: Colors.text,
+  },
+  tileLabel: {
     ...Typography.caption,
     color: Colors.text,
   },


### PR DESCRIPTION
## Summary
- show real streak, level, and mana values in Home stats tiles
- add styles for value and label, including compact mana tile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bcab3d1a483279615e1ac7ae5ceca