### PR TITLE
feat: add greeting and stats summary to welcome card

### DIFF
--- a/src/components/home/HomeWelcomeCard.js
+++ b/src/components/home/HomeWelcomeCard.js
@@ -1,17 +1,26 @@
-// [MB] Módulo: Home / Componente: HomeWelcomeCard
+// [MB] Módulo: Home / Sección: HomeWelcomeCard
 // Afecta: HomeScreen
-// Propósito: Tarjeta de bienvenida placeholder para el usuario
-// Puntos de edición futura: reemplazar por contenido dinámico
+// Propósito: Tarjeta de bienvenida con saludo y resumen dinámico
+// Puntos de edición futura: reemplazar placeholder de nombre
 // Autor: Codex - Fecha: 2025-08-12
 
 import React from "react";
 import { View, Text } from "react-native";
 import styles from "./HomeWelcomeCard.styles";
+import { useAppState, useProgress } from "../../state/AppContext";
 
 export default function HomeWelcomeCard() {
+  const { plantState, streak, mana } = useAppState();
+  const { level } = useProgress();
+
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Bienvenido de vuelta</Text>
+      <Text accessibilityRole="header" style={styles.title}>
+        ¡Hola, Jugador!
+      </Text>
+      <Text style={styles.subtitle}>
+        Planta: {plantState} · Nivel {level} · Racha {streak} · Maná {mana}
+      </Text>
     </View>
   );
 }

--- a/src/components/home/HomeWelcomeCard.styles.js
+++ b/src/components/home/HomeWelcomeCard.styles.js
@@ -1,7 +1,7 @@
 // [MB] Módulo: Home / Estilos: HomeWelcomeCard
 // Afecta: HomeScreen
-// Propósito: Estilos placeholder para tarjeta de bienvenida
-// Puntos de edición futura: ajustar layout y gráficos
+// Propósito: Estilos para saludo y resumen de estado
+// Puntos de edición futura: ajustar layout o añadir gráficos
 // Autor: Codex - Fecha: 2025-08-12
 
 import { StyleSheet } from "react-native";
@@ -24,5 +24,10 @@ export default StyleSheet.create({
   title: {
     ...Typography.h2,
     color: Colors.text,
+  },
+  subtitle: {
+    ...Typography.body,
+    color: Colors.text,
+    marginTop: Spacing.tiny,
   },
 });


### PR DESCRIPTION
## Summary
- show greeting header and summary in home welcome card
- style subtitle for welcome card

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bcb9d44d8832787763534b4794bc8