### PR TITLE
feat: show event countdown

### DIFF
--- a/src/components/home/EventBanner.js
+++ b/src/components/home/EventBanner.js
@@ -1,17 +1,27 @@
 // [MB] Módulo: Home / Componente: EventBanner
 // Afecta: HomeScreen
-// Propósito: Banner placeholder para eventos
-// Puntos de edición futura: reemplazar por promoción dinámica
+// Propósito: Banner de evento con cuenta regresiva
+// Puntos de edición futura: reemplazar fecha fija por datos dinámicos
 // Autor: Codex - Fecha: 2025-08-12
 
 import React from "react";
 import { View, Text } from "react-native";
 import styles from "./EventBanner.styles";
 
+const EVENT_DATE = "2025-12-31T23:59:59.000Z";
+
 export default function EventBanner() {
+  const daysRemaining = Math.max(
+    0,
+    Math.ceil((new Date(EVENT_DATE) - Date.now()) / 86400000)
+  );
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Próximo Evento</Text>
+      <View style={styles.chip} accessibilityRole="text">
+        <Text style={styles.chipText}>{`${daysRemaining} días restantes`}</Text>
+      </View>
     </View>
   );
 }

--- a/src/components/home/EventBanner.styles.js
+++ b/src/components/home/EventBanner.styles.js
@@ -1,7 +1,7 @@
 // [MB] Módulo: Home / Estilos: EventBanner
 // Afecta: HomeScreen
-// Propósito: Estilos placeholder para banner de eventos
-// Puntos de edición futura: agregar imágenes y enlaces
+// Propósito: Estilos para banner de evento con chip de días restantes
+// Puntos de edición futura: agregar imágenes, enlaces y fecha dinámica
 // Autor: Codex - Fecha: 2025-08-12
 
 import { StyleSheet } from "react-native";
@@ -23,6 +23,19 @@ export default StyleSheet.create({
   },
   title: {
     ...Typography.h2,
+    color: Colors.text,
+  },
+  chip: {
+    backgroundColor: Colors.surfaceElevated,
+    borderRadius: Radii.pill,
+    paddingHorizontal: Spacing.base,
+    height: 28,
+    justifyContent: "center",
+    marginTop: Spacing.small,
+    alignSelf: "flex-start",
+  },
+  chipText: {
+    ...Typography.caption,
     color: Colors.text,
   },
 });


### PR DESCRIPTION
## Summary
- display banner with days remaining until event using a fixed date
- add chip styles and accessibility label

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bd199bb1483279acc93bec56a37fd