### PR TITLE
feat: show empty states on home sections

### DIFF
--- a/src/components/home/DailyChallengesSection.js
+++ b/src/components/home/DailyChallengesSection.js
@@ -13,6 +13,8 @@ export default function DailyChallengesSection() {
   const dispatch = useAppDispatch();
   const { items } = useDailyChallenges();
 
+  const allClaimed = items.every((item) => item.claimed);
+
   const handleClaim = (id) => {
     dispatch({ type: "CLAIM_DAILY_CHALLENGE", payload: { id } });
   };
@@ -20,52 +22,56 @@ export default function DailyChallengesSection() {
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Desafíos Diarios</Text>
-      {items.map((item) => {
-        const canClaim = item.progress >= item.goal && !item.claimed;
-        const buttonLabel = canClaim
-          ? "Reclamar"
-          : item.claimed
-          ? "Reclamado"
-          : "En progreso";
-        return (
-          <View key={item.id} style={styles.card}>
-            <View style={styles.headerRow}>
-              <Text style={styles.challengeTitle}>{item.title}</Text>
-              <View style={styles.rewardPill}>
-                <Text style={styles.rewardText}>{`+${item.reward.xp} XP / +${item.reward.mana} Maná`}</Text>
+      {allClaimed ? (
+        <Text style={styles.emptyText}>¡Todo al día! Vuelve mañana</Text>
+      ) : (
+        items.map((item) => {
+          const canClaim = item.progress >= item.goal && !item.claimed;
+          const buttonLabel = canClaim
+            ? "Reclamar"
+            : item.claimed
+            ? "Reclamado"
+            : "En progreso";
+          return (
+            <View key={item.id} style={styles.card}>
+              <View style={styles.headerRow}>
+                <Text style={styles.challengeTitle}>{item.title}</Text>
+                <View style={styles.rewardPill}>
+                  <Text style={styles.rewardText}>{`+${item.reward.xp} XP / +${item.reward.mana} Maná`}</Text>
+                </View>
               </View>
-            </View>
-            <View style={styles.progressBar}>
-              <View
+              <View style={styles.progressBar}>
+                <View
+                  style={[
+                    styles.progressFill,
+                    { width: `${(item.progress / item.goal) * 100}%` },
+                  ]}
+                />
+              </View>
+              <Text style={styles.progressText}>{`${item.progress}/${item.goal}`}</Text>
+              <Pressable
+                onPress={() => handleClaim(item.id)}
+                disabled={!canClaim}
                 style={[
-                  styles.progressFill,
-                  { width: `${(item.progress / item.goal) * 100}%` },
+                  styles.claimButton,
+                  canClaim ? styles.claimButtonEnabled : styles.claimButtonDisabled,
                 ]}
-              />
-            </View>
-            <Text style={styles.progressText}>{`${item.progress}/${item.goal}`}</Text>
-            <Pressable
-              onPress={() => handleClaim(item.id)}
-              disabled={!canClaim}
-              style={[
-                styles.claimButton,
-                canClaim ? styles.claimButtonEnabled : styles.claimButtonDisabled,
-              ]}
-              accessibilityRole="button"
-              accessibilityLabel={`${buttonLabel} desafío ${item.title}`}
-            >
-              <Text
-                style={[
-                  styles.claimButtonText,
-                  !canClaim && styles.claimButtonTextDisabled,
-                ]}
+                accessibilityRole="button"
+                accessibilityLabel={`${buttonLabel} desafío ${item.title}`}
               >
-                {buttonLabel}
-              </Text>
-            </Pressable>
-          </View>
-        );
-      })}
+                <Text
+                  style={[
+                    styles.claimButtonText,
+                    !canClaim && styles.claimButtonTextDisabled,
+                  ]}
+                >
+                  {buttonLabel}
+                </Text>
+              </Pressable>
+            </View>
+          );
+        })
+      )}
     </View>
   );
 }

--- a/src/components/home/DailyChallengesSection.styles.js
+++ b/src/components/home/DailyChallengesSection.styles.js
@@ -88,4 +88,10 @@ export default StyleSheet.create({
   claimButtonTextDisabled: {
     color: Colors.textMuted,
   },
+  emptyText: {
+    ...Typography.body,
+    color: Colors.textMuted,
+    textAlign: "center",
+    marginTop: Spacing.base,
+  },
 });

--- a/src/components/home/InventorySection.js
+++ b/src/components/home/InventorySection.js
@@ -14,7 +14,7 @@ import {
 } from "../../state/AppContext";
 import { Opacity } from "../../theme";
 
-export default function InventorySection() {
+export default function InventorySection({ onShopPress }) {
   const { inventory } = useAppState();
   const dispatch = useAppDispatch();
   const counts = useInventoryCounts();
@@ -37,6 +37,23 @@ export default function InventorySection() {
       Alert.alert("Poción usada", "Cristal de Maná +100");
     }
   };
+
+  if (counts.total === 0) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>Inventario</Text>
+        <Text style={styles.emptyText}>Tu inventario está vacío</Text>
+        <Pressable
+          onPress={onShopPress}
+          style={styles.viewAllButton}
+          accessibilityRole="button"
+          accessibilityLabel="Ir a la Tienda"
+        >
+          <Text style={styles.viewAllText}>Ir a la Tienda</Text>
+        </Pressable>
+      </View>
+    );
+  }
 
   return (
     <View style={styles.container}>

--- a/src/components/home/InventorySection.styles.js
+++ b/src/components/home/InventorySection.styles.js
@@ -81,4 +81,10 @@ export default StyleSheet.create({
     ...Typography.body,
     color: Colors.text,
   },
+  emptyText: {
+    ...Typography.body,
+    color: Colors.textMuted,
+    textAlign: "center",
+    marginTop: Spacing.base,
+  },
 });

--- a/src/components/home/MagicShopSection.js
+++ b/src/components/home/MagicShopSection.js
@@ -32,7 +32,7 @@ const SHOP_ITEMS = {
   ],
 };
 
-export default function MagicShopSection() {
+export default function MagicShopSection({ onLayout }) {
   const [activeTab, setActiveTab] = useState("potions");
   const { mana } = useAppState();
   const dispatch = useAppDispatch();
@@ -42,7 +42,7 @@ export default function MagicShopSection() {
     dispatch({ type: "SET_MANA", payload: mana + 5 });
 
   return (
-    <View style={styles.container}>
+    <View style={styles.container} onLayout={onLayout}>
       <Text style={styles.title}>Tienda Mágica</Text>
       <Text style={styles.subtitle}>Las pociones compradas se guardan en Inventario</Text>
 

--- a/src/components/home/NewsFeedSection.js
+++ b/src/components/home/NewsFeedSection.js
@@ -39,20 +39,24 @@ export default function NewsFeedSection() {
           <Text style={styles.markAll}>Marcar todo como leído</Text>
         </TouchableOpacity>
       </View>
-      {items.map((item) => (
-        <TouchableOpacity
-          key={item.id}
-          style={styles.row}
-          onPress={() => handlePress(item.id)}
-        >
-          <Ionicons name={item.iconName} size={20} color={Colors.text} />
-          <View style={styles.rowText}>
-            <Text style={styles.rowTitle}>{item.title}</Text>
-            <Text style={styles.time}>{timeAgo(item.timestamp)}</Text>
-          </View>
-          {!item.read && <View style={styles.unreadDot} />}
-        </TouchableOpacity>
-      ))}
+      {items.length === 0 ? (
+        <Text style={styles.emptyText}>No hay noticias por ahora</Text>
+      ) : (
+        items.map((item) => (
+          <TouchableOpacity
+            key={item.id}
+            style={styles.row}
+            onPress={() => handlePress(item.id)}
+          >
+            <Ionicons name={item.iconName} size={20} color={Colors.text} />
+            <View style={styles.rowText}>
+              <Text style={styles.rowTitle}>{item.title}</Text>
+              <Text style={styles.time}>{timeAgo(item.timestamp)}</Text>
+            </View>
+            {!item.read && <View style={styles.unreadDot} />}
+          </TouchableOpacity>
+        ))
+      )}
     </View>
   );
 }

--- a/src/components/home/NewsFeedSection.styles.js
+++ b/src/components/home/NewsFeedSection.styles.js
@@ -56,4 +56,10 @@ export default StyleSheet.create({
     borderRadius: Radii.pill,
     backgroundColor: Colors.accent,
   },
+  emptyText: {
+    ...Typography.body,
+    color: Colors.textMuted,
+    textAlign: "center",
+    marginTop: Spacing.base,
+  },
 });

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -4,7 +4,7 @@
 // Puntos de edición futura: conectar datos reales y navegación
 // Autor: Codex - Fecha: 2025-08-12
 
-import React from "react";
+import React, { useRef, useState } from "react";
 import { StyleSheet, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Colors, Spacing } from "../theme";
@@ -21,11 +21,18 @@ import { useAppState } from "../state/AppContext";
 
 export default function HomeScreen() {
   const { mana, plantState } = useAppState();
+  const scrollRef = useRef(null);
+  const [shopY, setShopY] = useState(0);
+
+  const handleShopLayout = (e) => setShopY(e.nativeEvent.layout.y);
+  const scrollToShop = () =>
+    scrollRef.current?.scrollTo({ y: shopY, animated: true });
 
   return (
     <SafeAreaView style={styles.container}>
       <HomeScreenHeader userName="Jugador" manaCount={mana} plantState={plantState} />
       <ScrollView
+        ref={scrollRef}
         contentContainerStyle={{
           paddingHorizontal: Spacing.base,
           paddingBottom: 96,
@@ -34,8 +41,8 @@ export default function HomeScreen() {
         <HomeWelcomeCard />
         <DailyRewardSection />
         <DailyChallengesSection />
-        <MagicShopSection />
-        <InventorySection />
+        <MagicShopSection onLayout={handleShopLayout} />
+        <InventorySection onShopPress={scrollToShop} />
         <NewsFeedSection />
         <StatsQuickTiles />
         <EventBanner />


### PR DESCRIPTION
## Summary
- add empty message and shop redirect button when inventory is empty
- show placeholder when news feed has no items
- warn user when all daily challenges are claimed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bd296dfc48327bf96e4da091a7378