### PR TITLE
feat: show placeholders during state hydration

### DIFF
--- a/src/components/home/DailyChallengesSection.js
+++ b/src/components/home/DailyChallengesSection.js
@@ -2,22 +2,32 @@
 // Afecta: HomeScreen
 // Propósito: Mostrar desafíos diarios con progreso y reclamo de recompensas
 // Puntos de edición futura: animaciones y estados avanzados
-// Autor: Codex - Fecha: 2025-08-12
+// Autor: Codex - Fecha: 2025-08-13
 
 import React from "react";
 import { View, Text, Pressable } from "react-native";
 import styles from "./DailyChallengesSection.styles";
-import { useDailyChallenges, useAppDispatch } from "../../state/AppContext";
+import {
+  useDailyChallenges,
+  useAppDispatch,
+  useHydrationStatus,
+} from "../../state/AppContext";
+import SectionPlaceholder from "./SectionPlaceholder";
 
 export default function DailyChallengesSection() {
   const dispatch = useAppDispatch();
   const { items } = useDailyChallenges();
+  const hydration = useHydrationStatus();
 
   const allClaimed = items.every((item) => item.claimed);
 
   const handleClaim = (id) => {
     dispatch({ type: "CLAIM_DAILY_CHALLENGE", payload: { id } });
   };
+
+  if (hydration.challenges) {
+    return <SectionPlaceholder height={220} />;
+  }
 
   return (
     <View style={styles.container}>

--- a/src/components/home/DailyRewardSection.js
+++ b/src/components/home/DailyRewardSection.js
@@ -2,7 +2,7 @@
 // Afecta: HomeScreen
 // Propósito: Mostrar botón para reclamar recompensa diaria
 // Puntos de edición futura: integrar animaciones y estados visuales
-// Autor: Codex - Fecha: 2025-08-12
+// Autor: Codex - Fecha: 2025-08-13
 
 import React from "react";
 import { View, Text, Pressable } from "react-native";
@@ -12,16 +12,23 @@ import {
   useAppState,
   useCanClaimToday,
   DAILY_REWARD_MANA,
+  useHydrationStatus,
 } from "../../state/AppContext";
+import SectionPlaceholder from "./SectionPlaceholder";
 
 export default function DailyRewardSection() {
   const dispatch = useAppDispatch();
   const { streak } = useAppState();
   const canClaimToday = useCanClaimToday();
+  const hydration = useHydrationStatus();
 
   const handleClaim = () => {
     dispatch({ type: "CLAIM_DAILY_REWARD" });
   };
+
+  if (hydration.progress) {
+    return <SectionPlaceholder height={110} />;
+  }
 
   return (
     <View style={styles.container}>

--- a/src/components/home/HomeWelcomeCard.js
+++ b/src/components/home/HomeWelcomeCard.js
@@ -2,16 +2,26 @@
 // Afecta: HomeScreen
 // Propósito: Tarjeta de bienvenida con saludo y resumen dinámico
 // Puntos de edición futura: reemplazar placeholder de nombre
-// Autor: Codex - Fecha: 2025-08-12
+// Autor: Codex - Fecha: 2025-08-13
 
 import React from "react";
 import { View, Text } from "react-native";
 import styles from "./HomeWelcomeCard.styles";
-import { useAppState, useProgress } from "../../state/AppContext";
+import {
+  useAppState,
+  useProgress,
+  useHydrationStatus,
+} from "../../state/AppContext";
+import SectionPlaceholder from "./SectionPlaceholder";
 
 export default function HomeWelcomeCard() {
   const { plantState, streak, mana } = useAppState();
   const { level } = useProgress();
+  const hydration = useHydrationStatus();
+
+  if (hydration.mana || hydration.progress) {
+    return <SectionPlaceholder height={80} />;
+  }
 
   return (
     <View style={styles.container}>

--- a/src/components/home/InventorySection.js
+++ b/src/components/home/InventorySection.js
@@ -2,7 +2,7 @@
 // Afecta: HomeScreen
 // Propósito: Resumen de inventario con conteos y lista corta
 // Puntos de edición futura: navegación a inventario completo
-// Autor: Codex - Fecha: 2025-08-12
+// Autor: Codex - Fecha: 2025-08-13
 
 import React from "react";
 import { View, Text, Pressable, Alert } from "react-native";
@@ -11,13 +11,16 @@ import {
   useAppState,
   useAppDispatch,
   useInventoryCounts,
+  useHydrationStatus,
 } from "../../state/AppContext";
 import { Opacity } from "../../theme";
+import SectionPlaceholder from "./SectionPlaceholder";
 
 export default function InventorySection({ onShopPress }) {
   const { inventory } = useAppState();
   const dispatch = useAppDispatch();
   const counts = useInventoryCounts();
+  const hydration = useHydrationStatus();
   const topItems = inventory.slice(0, 3);
 
   const handleUse = (item) => {
@@ -37,6 +40,10 @@ export default function InventorySection({ onShopPress }) {
       Alert.alert("Poción usada", "Cristal de Maná +100");
     }
   };
+
+  if (hydration.inventory) {
+    return <SectionPlaceholder height={220} />;
+  }
 
   if (counts.total === 0) {
     return (

--- a/src/components/home/MagicShopSection.js
+++ b/src/components/home/MagicShopSection.js
@@ -2,7 +2,7 @@
 // Afecta: HomeScreen
 // Propósito: Sección de tienda mágica con tabs y maná disponible
 // Puntos de edición futura: integrar productos, navegación y retirar debug
-// Autor: Codex - Fecha: 2025-08-12
+// Autor: Codex - Fecha: 2025-08-13
 
 import React, { useState } from "react";
 import { View, Text, Pressable, Alert } from "react-native";
@@ -14,7 +14,9 @@ import {
   useAppState,
   useAppDispatch,
   useCanAfford,
+  useHydrationStatus,
 } from "../../state/AppContext";
+import SectionPlaceholder from "./SectionPlaceholder";
 
 const TABS = [
   { key: "potions", label: "Pociones" },
@@ -78,8 +80,13 @@ export default function MagicShopSection({ onLayout }) {
   const { mana } = useAppState();
   const dispatch = useAppDispatch();
   const canAfford = useCanAfford();
+  const hydration = useHydrationStatus();
 
   const addDebugMana = () => dispatch({ type: "SET_MANA", payload: mana + 5 });
+
+  if (hydration.mana) {
+    return <SectionPlaceholder height={300} />;
+  }
 
   return (
     <View style={styles.container} onLayout={onLayout}>

--- a/src/components/home/NewsFeedSection.js
+++ b/src/components/home/NewsFeedSection.js
@@ -2,14 +2,19 @@
 // Afecta: HomeScreen
 // Propósito: Mostrar noticias con marca de leído y persistencia
 // Puntos de edición futura: conectar con feed real y ajustar estilos
-// Autor: Codex - Fecha: 2025-08-12
+// Autor: Codex - Fecha: 2025-08-13
 
 import React from "react";
 import { View, Text, TouchableOpacity } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { Colors } from "../../theme";
 import styles from "./NewsFeedSection.styles";
-import { useNewsFeed, useAppDispatch } from "../../state/AppContext";
+import {
+  useNewsFeed,
+  useAppDispatch,
+  useHydrationStatus,
+} from "../../state/AppContext";
+import SectionPlaceholder from "./SectionPlaceholder";
 
 function timeAgo(iso) {
   const diffMs = Date.now() - new Date(iso).getTime();
@@ -25,11 +30,16 @@ function timeAgo(iso) {
 export default function NewsFeedSection() {
   const { items } = useNewsFeed();
   const dispatch = useAppDispatch();
+  const hydration = useHydrationStatus();
 
   const markAll = () => dispatch({ type: "MARK_ALL_NEWS_READ" });
   const handlePress = (id) => {
     dispatch({ type: "MARK_NEWS_READ", payload: { id } });
   };
+
+  if (hydration.news) {
+    return <SectionPlaceholder height={220} />;
+  }
 
   return (
     <View style={styles.container}>

--- a/src/components/home/SectionPlaceholder.js
+++ b/src/components/home/SectionPlaceholder.js
@@ -1,0 +1,26 @@
+// [MB] Módulo: Home / Componente: SectionPlaceholder
+// Afecta: HomeScreen
+// Propósito: Placeholder temporal mientras se hidrata el estado
+// Puntos de edición futura: animaciones o skeletons
+// Autor: Codex - Fecha: 2025-08-13
+
+import React from "react";
+import { View, Text } from "react-native";
+import { Colors, Radii } from "../../theme";
+
+export default function SectionPlaceholder({ height }) {
+  return (
+    <View
+      style={{
+        height,
+        backgroundColor: Colors.surface,
+        borderRadius: Radii.lg,
+        opacity: 0.5,
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <Text style={{ color: Colors.text }}>Cargando…</Text>
+    </View>
+  );
+}

--- a/src/components/home/StatsQuickTiles.js
+++ b/src/components/home/StatsQuickTiles.js
@@ -2,16 +2,26 @@
 // Afecta: HomeScreen
 // Propósito: Mostrar racha, nivel y maná desde el contexto
 // Puntos de edición futura: añadir más estadísticas o gráficos
-// Autor: Codex - Fecha: 2025-08-12
+// Autor: Codex - Fecha: 2025-08-13
 
 import React from "react";
 import { View, Text } from "react-native";
 import styles from "./StatsQuickTiles.styles";
-import { useAppState, useProgress } from "../../state/AppContext";
+import {
+  useAppState,
+  useProgress,
+  useHydrationStatus,
+} from "../../state/AppContext";
+import SectionPlaceholder from "./SectionPlaceholder";
 
 export default function StatsQuickTiles() {
   const { streak, mana } = useAppState();
   const { level } = useProgress();
+  const hydration = useHydrationStatus();
+
+  if (hydration.mana || hydration.progress) {
+    return <SectionPlaceholder height={140} />;
+  }
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
## Summary
- track hydration per module in context and expose `useHydrationStatus`
- add reusable `SectionPlaceholder` view
- render placeholders across Home sections while mana, progress, inventory, news or challenges load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bd6c3ee108327b430535863670fc1