### PR TITLE
feat(economy): saldos de monedas y diamantes con persistencia + UI en Home/Tienda

### DIFF
--- a/src/components/home/MagicShopSection.js
+++ b/src/components/home/MagicShopSection.js
@@ -9,12 +9,13 @@ import { View, Text, Pressable, Alert } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import styles from "./MagicShopSection.styles";
 import ShopItemCard from "./ShopItemCard";
-import { ShopColors } from "../../theme";
+import { ShopColors, Colors } from "../../theme";
 import {
   useAppState,
   useAppDispatch,
   useCanAfford,
   useHydrationStatus,
+  useWallet,
 } from "../../state/AppContext";
 import SectionPlaceholder from "./SectionPlaceholder";
 
@@ -81,10 +82,11 @@ export default function MagicShopSection({ onLayout }) {
   const dispatch = useAppDispatch();
   const canAfford = useCanAfford();
   const hydration = useHydrationStatus();
+  const { coin, gem } = useWallet();
 
   const addDebugMana = () => dispatch({ type: "SET_MANA", payload: mana + 5 });
 
-  if (hydration.mana) {
+  if (hydration.mana || hydration.wallet) {
     return <SectionPlaceholder height={300} />;
   }
 
@@ -102,17 +104,39 @@ export default function MagicShopSection({ onLayout }) {
           Maná disponible
         </Text>
         <View
+          style={styles.walletPills}
           accessible
-          accessibilityLabel={`Maná disponible: ${mana}`}
-          style={[styles.manaPill, { borderColor: ShopColors[activeTab].pill }]}
+          accessibilityLabel={`Saldo: ${mana} maná, ${coin} monedas, ${gem} diamantes`}
         >
-          <Ionicons
-            name="sparkles"
-            size={16}
-            color={ShopColors[activeTab].pill}
-            style={styles.manaIcon}
-          />
-          <Text style={styles.manaValue}>{mana}</Text>
+          <View
+            style={[styles.manaPill, { borderColor: ShopColors[activeTab].pill }]}
+          >
+            <Ionicons
+              name="sparkles"
+              size={16}
+              color={ShopColors[activeTab].pill}
+              style={styles.manaIcon}
+            />
+            <Text style={styles.manaValue}>{mana}</Text>
+          </View>
+          <View style={styles.currencyPill}>
+            <Ionicons
+              name="logo-bitcoin"
+              size={14}
+              color={Colors.text}
+              style={styles.currencyIcon}
+            />
+            <Text style={styles.currencyValue}>{coin}</Text>
+          </View>
+          <View style={styles.currencyPill}>
+            <Ionicons
+              name="diamond"
+              size={14}
+              color={Colors.text}
+              style={styles.currencyIcon}
+            />
+            <Text style={styles.currencyValue}>{gem}</Text>
+          </View>
         </View>
       </View>
 

--- a/src/components/home/MagicShopSection.styles.js
+++ b/src/components/home/MagicShopSection.styles.js
@@ -2,7 +2,7 @@
 // Afecta: HomeScreen
 // Propósito: Estilos para sección de tienda mágica con tabs y cards
 // Puntos de edición futura: diferenciar categorías y tarjetas, retirar debug
-// Autor: Codex - Fecha: 2025-08-12
+// Autor: Codex - Fecha: 2025-08-13
 
 import { StyleSheet } from "react-native";
 import { Colors, Spacing, Radii, Elevation, Typography } from "../../theme";
@@ -49,6 +49,27 @@ export default StyleSheet.create({
   },
   manaValue: {
     ...Typography.body,
+    color: Colors.text,
+  },
+  walletPills: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  currencyPill: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: Radii.pill,
+    paddingHorizontal: Spacing.small,
+    height: 24,
+    marginLeft: Spacing.small,
+  },
+  currencyIcon: {
+    marginRight: Spacing.tiny,
+  },
+  currencyValue: {
+    ...Typography.caption,
     color: Colors.text,
   },
   tabsRow: {

--- a/src/storage.js
+++ b/src/storage.js
@@ -2,7 +2,7 @@
 // Afecta: AppContext (persistencia de maná, rachas, progreso, tareas, desafíos y noticias)
 // Propósito: Persistir datos básicos de usuario en AsyncStorage
 // Puntos de edición futura: extender a otros campos y manejo de errores
-// Autor: Codex - Fecha: 2025-08-12
+// Autor: Codex - Fecha: 2025-08-13
 
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
@@ -14,6 +14,7 @@ const TASKS_KEY = "mb:tasks";
 const INVENTORY_KEY = "mb:inventory";
 const DAILY_CHALLENGES_KEY = "mb:dailyChallenges";
 const NEWS_KEY = "mb:news";
+const WALLET_KEY = "mb:wallet";
 
 export async function getMana() {
   try {
@@ -72,6 +73,30 @@ export async function setLastClaimDate(value) {
     await AsyncStorage.setItem(LAST_CLAIM_DATE_KEY, value);
   } catch (e) {
     console.warn("Error guardando fecha de reclamo en storage", e);
+  }
+}
+
+// [MB] Helpers de wallet (monedas y diamantes)
+const DEFAULT_WALLET = { coin: 0, gem: 0 };
+
+export async function getWallet() {
+  try {
+    const value = await AsyncStorage.getItem(WALLET_KEY);
+    if (value) {
+      const parsed = JSON.parse(value);
+      return { ...DEFAULT_WALLET, ...parsed };
+    }
+  } catch (e) {
+    console.warn("Error leyendo wallet de storage", e);
+  }
+  return { ...DEFAULT_WALLET };
+}
+
+export async function setWallet(wallet) {
+  try {
+    await AsyncStorage.setItem(WALLET_KEY, JSON.stringify(wallet));
+  } catch (e) {
+    console.warn("Error guardando wallet en storage", e);
   }
 }
 


### PR DESCRIPTION
## Summary
- add wallet helpers to AsyncStorage for coins and gems
- manage coin/gem balances in AppContext with new actions and selectors
- display coin and gem pills in MagicShopSection alongside mana

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bddcddd4083279fec3f832fd3fe2f