### PR TITLE
feat(achievements): motor v1 con plantillas y sección en Home

### DIFF
--- a/src/components/home/AchievementsSection.js
+++ b/src/components/home/AchievementsSection.js
@@ -1,0 +1,73 @@
+// [MB] Módulo: Home / Sección: AchievementsSection
+// Afecta: HomeScreen
+// Propósito: Mostrar logros desbloqueados y próximos a completar
+// Puntos de edición futura: navegación a listado completo y mejoras visuales
+// Autor: Codex - Fecha: 2025-08-17
+
+import React from "react";
+import { View, Text, Pressable } from "react-native";
+import styles from "./AchievementsSection.styles";
+import {
+  useTopAchievements,
+  useAppDispatch,
+  useHydrationStatus,
+} from "../../state/AppContext";
+import SectionPlaceholder from "./SectionPlaceholder";
+
+export default function AchievementsSection() {
+  const dispatch = useAppDispatch();
+  const achievements = useTopAchievements();
+  const hydration = useHydrationStatus();
+
+  if (hydration.achievements) {
+    return <SectionPlaceholder height={220} />;
+  }
+
+  const handleClaim = (id) => {
+    dispatch({ type: "CLAIM_ACHIEVEMENT", payload: { id } });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title} accessibilityRole="header">
+        Logros
+      </Text>
+      {achievements.map((ach) => {
+        const progressPct = Math.min(1, ach.progress / ach.goal);
+        const canClaim = ach.unlocked && !ach.claimed;
+        const progressText = `${Math.min(ach.progress, ach.goal)}/${ach.goal}`;
+        return (
+          <View key={ach.id} style={styles.card}>
+            <Text style={styles.achievementTitle}>{ach.title}</Text>
+            <View style={styles.progressBar}>
+              <View
+                style={[styles.progressFill, { width: `${progressPct * 100}%` }]}
+              />
+            </View>
+            <Text style={styles.progressText}>{progressText}</Text>
+            {canClaim ? (
+              <Pressable
+                onPress={() => handleClaim(ach.id)}
+                style={styles.claimButton}
+                accessibilityRole="button"
+                accessibilityLabel={`Reclamar logro ${ach.title}`}
+              >
+                <Text style={styles.claimButtonText}>Reclamar</Text>
+              </Pressable>
+            ) : ach.unlocked ? (
+              <Text style={styles.readyText}>Listo para reclamar</Text>
+            ) : null}
+          </View>
+        );
+      })}
+      <Pressable
+        onPress={() => {}}
+        style={styles.viewAllButton}
+        accessibilityRole="button"
+        accessibilityLabel="Ver todos los logros"
+      >
+        <Text style={styles.viewAllText}>Ver todos</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/src/components/home/AchievementsSection.styles.js
+++ b/src/components/home/AchievementsSection.styles.js
@@ -1,0 +1,77 @@
+// [MB] Módulo: Home / Estilos: AchievementsSection
+// Afecta: HomeScreen
+// Propósito: Estilos para cards de logros
+// Puntos de edición futura: colores y disposición de elementos
+// Autor: Codex - Fecha: 2025-08-17
+
+import { StyleSheet } from "react-native";
+import { Colors, Spacing, Radii, Elevation, Typography } from "../../theme";
+
+export default StyleSheet.create({
+  container: {
+    backgroundColor: Colors.surface,
+    padding: Spacing.base,
+    borderRadius: Radii.md,
+    marginBottom: Spacing.tiny,
+    ...Elevation.card,
+  },
+  title: {
+    ...Typography.h2,
+    color: Colors.text,
+  },
+  card: {
+    backgroundColor: Colors.surfaceAlt,
+    padding: Spacing.base,
+    borderRadius: Radii.md,
+    marginTop: Spacing.tiny,
+  },
+  achievementTitle: {
+    ...Typography.body,
+    color: Colors.text,
+    marginBottom: Spacing.small,
+  },
+  progressBar: {
+    height: 6,
+    backgroundColor: Colors.border,
+    borderRadius: Radii.pill,
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    backgroundColor: Colors.secondary,
+    borderRadius: Radii.pill,
+  },
+  progressText: {
+    ...Typography.caption,
+    color: Colors.textMuted,
+    marginTop: Spacing.tiny,
+  },
+  claimButton: {
+    marginTop: Spacing.small,
+    paddingVertical: Spacing.small,
+    borderRadius: Radii.md,
+    alignItems: "center",
+    backgroundColor: Colors.buttonBg,
+  },
+  claimButtonText: {
+    ...Typography.body,
+    color: Colors.textInverse,
+  },
+  readyText: {
+    ...Typography.caption,
+    color: Colors.text,
+    marginTop: Spacing.small,
+  },
+  viewAllButton: {
+    marginTop: Spacing.base,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: Radii.md,
+    paddingVertical: Spacing.small,
+    alignItems: "center",
+  },
+  viewAllText: {
+    ...Typography.body,
+    color: Colors.text,
+  },
+});

--- a/src/components/home/DailyChallengesSection.js
+++ b/src/components/home/DailyChallengesSection.js
@@ -2,7 +2,7 @@
 // Afecta: HomeScreen
 // Propósito: Mostrar desafíos diarios con progreso y reclamo de recompensas
 // Puntos de edición futura: animaciones y estados avanzados
-// Autor: Codex - Fecha: 2025-08-13
+// Autor: Codex - Fecha: 2025-08-17
 
 import React from "react";
 import { View, Text, Pressable } from "react-native";
@@ -23,6 +23,7 @@ export default function DailyChallengesSection() {
 
   const handleClaim = (id) => {
     dispatch({ type: "CLAIM_DAILY_CHALLENGE", payload: { id } });
+    dispatch({ type: "ACHIEVEMENT_EVENT", payload: { type: "challenge_claimed" } });
   };
 
   if (hydration.challenges) {

--- a/src/components/home/DailyRewardSection.js
+++ b/src/components/home/DailyRewardSection.js
@@ -2,7 +2,7 @@
 // Afecta: HomeScreen
 // Propósito: Mostrar recompensa diaria y permitir su reclamo
 // Puntos de edición futura: integrar animaciones y estados visuales
-// Autor: Codex - Fecha: 2025-08-13
+// Autor: Codex - Fecha: 2025-08-17
 
 import React from "react";
 import { View, Text, Pressable } from "react-native";

--- a/src/components/home/MagicShopSection.js
+++ b/src/components/home/MagicShopSection.js
@@ -2,7 +2,7 @@
 // Afecta: HomeScreen
 // Propósito: Sección de tienda mágica con tabs y maná disponible
 // Puntos de edición futura: integrar productos, navegación y retirar debug
-// Autor: Codex - Fecha: 2025-08-13
+// Autor: Codex - Fecha: 2025-08-17
 
 import React, { useState } from "react";
 import { View, Text, Pressable, Alert } from "react-native";
@@ -196,6 +196,16 @@ export default function MagicShopSection({ onLayout }) {
                       sku: `shop/${activeTab}/${item.id}`,
                       title: item.title,
                       category: activeTab,
+                    },
+                  });
+                  dispatch({
+                    type: "ACHIEVEMENT_EVENT",
+                    payload: {
+                      type: "purchase",
+                      payload: {
+                        sku: `shop/${activeTab}/${item.id}`,
+                        category: activeTab,
+                      },
                     },
                   });
                   Alert.alert("Compra exitosa — añadido al inventario");

--- a/src/components/home/StatsQuickTiles.js
+++ b/src/components/home/StatsQuickTiles.js
@@ -2,15 +2,16 @@
 // Afecta: HomeScreen
 // Propósito: Mostrar racha, nivel y maná desde el contexto
 // Puntos de edición futura: añadir más estadísticas o gráficos
-// Autor: Codex - Fecha: 2025-08-13
+// Autor: Codex - Fecha: 2025-08-17
 
 import React from "react";
-import { View, Text } from "react-native";
+import { View, Text, Pressable } from "react-native";
 import styles from "./StatsQuickTiles.styles";
 import {
   useAppState,
   useProgress,
   useHydrationStatus,
+  useAppDispatch,
 } from "../../state/AppContext";
 import SectionPlaceholder from "./SectionPlaceholder";
 
@@ -18,6 +19,7 @@ export default function StatsQuickTiles() {
   const { streak, mana } = useAppState();
   const { level } = useProgress();
   const hydration = useHydrationStatus();
+  const dispatch = useAppDispatch();
 
   if (hydration.mana || hydration.progress) {
     return <SectionPlaceholder height={140} />;
@@ -42,6 +44,21 @@ export default function StatsQuickTiles() {
           <Text style={styles.tileLabel}>Maná</Text>
         </View>
       </View>
+      {__DEV__ && (
+        <Pressable
+          onPress={() =>
+            dispatch({
+              type: "ACHIEVEMENT_EVENT",
+              payload: { type: "tool_usage", payload: { toolId: "pomodoro" } },
+            })
+          }
+          style={styles.debugButton}
+          accessibilityRole="button"
+          accessibilityLabel="Disparar uso de pomodoro"
+        >
+          <Text style={styles.debugButtonText}>Debug Pomodoro</Text>
+        </Pressable>
+      )}
     </View>
   );
 }

--- a/src/components/home/StatsQuickTiles.styles.js
+++ b/src/components/home/StatsQuickTiles.styles.js
@@ -2,7 +2,7 @@
 // Afecta: HomeScreen
 // Propósito: Estilos para racha, nivel y maná en mosaicos
 // Puntos de edición futura: ajustar layout o añadir animaciones
-// Autor: Codex - Fecha: 2025-08-12
+// Autor: Codex - Fecha: 2025-08-17
 
 import { StyleSheet } from "react-native";
 import { Colors, Spacing, Radii, Elevation, Typography } from "../../theme";
@@ -44,6 +44,19 @@ export default StyleSheet.create({
     color: Colors.text,
   },
   tileLabel: {
+    ...Typography.caption,
+    color: Colors.text,
+  },
+  debugButton: {
+    alignSelf: "flex-end",
+    marginTop: Spacing.base,
+    paddingVertical: Spacing.tiny,
+    paddingHorizontal: Spacing.base,
+    borderRadius: Radii.pill,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  debugButtonText: {
     ...Typography.caption,
     color: Colors.text,
   },

--- a/src/constants/achievements.js
+++ b/src/constants/achievements.js
@@ -1,0 +1,90 @@
+// [MB] Módulo: Achievements / Sección: Plantillas
+// Afecta: motor de logros
+// Propósito: Definir plantillas de logros iniciales
+// Puntos de edición futura: añadir nuevos logros y ajustar metas/recompensas
+// Autor: Codex - Fecha: 2025-08-17
+
+export const ACHIEVEMENTS = [
+  {
+    id: "t_tasks_10",
+    title: "Productivo I",
+    group: "progreso",
+    type: "count_event",
+    event: "task_done",
+    goal: 10,
+    reward: { mana: 20, coin: 50 },
+  },
+  {
+    id: "t_tasks_50",
+    title: "Productivo II",
+    group: "progreso",
+    type: "count_event",
+    event: "task_done",
+    goal: 50,
+    reward: { mana: 50, coin: 150 },
+  },
+  {
+    id: "t_urgent_10",
+    title: "Apaga-incendios",
+    group: "retos",
+    type: "count_event",
+    event: "task_done",
+    goal: 10,
+  },
+  {
+    id: "t_chal_7",
+    title: "Cazador de Retos",
+    group: "retos",
+    type: "count_event",
+    event: "challenge_claimed",
+    goal: 7,
+    reward: { coin: 150 },
+  },
+  {
+    id: "t_streak_7",
+    title: "Constancia I",
+    group: "progreso",
+    type: "reach_value",
+    metric: "streak",
+    goal: 7,
+    reward: { mana: 30 },
+  },
+  {
+    id: "t_streak_30",
+    title: "Constancia II",
+    group: "progreso",
+    type: "reach_value",
+    metric: "streak",
+    goal: 30,
+    reward: { gem: 1 },
+  },
+  {
+    id: "t_level_5",
+    title: "Cultivador I",
+    group: "progreso",
+    type: "reach_value",
+    metric: "level",
+    goal: 5,
+    reward: { mana: 40 },
+  },
+  {
+    id: "t_buys_10",
+    title: "Cliente Frecuente",
+    group: "econ",
+    type: "count_event",
+    event: "purchase",
+    goal: 10,
+    reward: { coin: 200 },
+  },
+  {
+    id: "t_pomo_15_20",
+    title: "Pomodoro Maestro",
+    group: "herramientas",
+    type: "window_count",
+    event: "tool_usage",
+    toolId: "pomodoro",
+    windowDays: 20,
+    goal: 15,
+    reward: { coin: 300 },
+  },
+];

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -2,7 +2,7 @@
 // Afecta: HomeScreen (layout principal)
 // Propósito: Renderizar secciones de inicio y mostrar estado global
 // Puntos de edición futura: conectar datos reales y navegación
-// Autor: Codex - Fecha: 2025-08-13
+// Autor: Codex - Fecha: 2025-08-17
 
 import React, { useRef, useState } from "react";
 import { StyleSheet, ScrollView } from "react-native";
@@ -12,6 +12,7 @@ import HomeScreenHeader from "../components/HomeScreenHeader";
 import HomeWelcomeCard from "../components/home/HomeWelcomeCard";
 import DailyRewardSection from "../components/home/DailyRewardSection";
 import DailyChallengesSection from "../components/home/DailyChallengesSection";
+import AchievementsSection from "../components/home/AchievementsSection";
 import MagicShopSection from "../components/home/MagicShopSection";
 import InventorySection from "../components/home/InventorySection";
 import NewsFeedSection from "../components/home/NewsFeedSection";
@@ -43,6 +44,7 @@ export default function HomeScreen() {
         <HomeWelcomeCard />
         <DailyRewardSection />
         <DailyChallengesSection />
+        <AchievementsSection />
         <MagicShopSection onLayout={handleShopLayout} />
         <InventorySection onShopPress={scrollToShop} />
         <NewsFeedSection />

--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -2,7 +2,7 @@
 // Afecta: TasksScreen (listado y gestión de tareas)
 // Propósito: Listar, filtrar y persistir tareas con recompensas seguras
 // Puntos de edición futura: manejo remoto y estilos de filtros
-// Autor: Codex - Fecha: 2025-08-12
+// Autor: Codex - Fecha: 2025-08-17
 
 import React, { useState, useEffect } from "react";
 import { SafeAreaView, FlatList, Modal, View } from "react-native";
@@ -234,12 +234,16 @@ export default function TasksScreen() {
         type: "APPLY_TASK_REWARD",
         payload: { xpDelta: xp, manaDelta: mana },
       });
-      dispatch({
-        type: "UPDATE_DAILY_CHALLENGES_ON_TASK_DONE",
-        payload: { priority: priorityLabel },
-      });
-    }
-  };
+        dispatch({
+          type: "UPDATE_DAILY_CHALLENGES_ON_TASK_DONE",
+          payload: { priority: priorityLabel },
+        });
+        dispatch({
+          type: "ACHIEVEMENT_EVENT",
+          payload: { type: "task_done", payload: { priority: priorityLabel } },
+        });
+      }
+    };
 
   const onSoftDeleteTask = (id) =>
     setTasks((prev) => prev.map((t) => (t.id === id ? { ...t, isDeleted: true } : t)));

--- a/src/storage.js
+++ b/src/storage.js
@@ -2,7 +2,7 @@
 // Afecta: AppContext (persistencia de maná, rachas, progreso, tareas, desafíos y noticias)
 // Propósito: Persistir datos básicos de usuario en AsyncStorage
 // Puntos de edición futura: extender a otros campos y manejo de errores
-// Autor: Codex - Fecha: 2025-08-13
+// Autor: Codex - Fecha: 2025-08-17
 
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
@@ -16,6 +16,7 @@ const DAILY_CHALLENGES_KEY = "mb:dailyChallenges";
 const NEWS_KEY = "mb:news";
 const WALLET_KEY = "mb:wallet";
 const DAILY_REWARD_KEY = "mb:dailyReward";
+const ACHIEVEMENTS_KEY = "mb:achievements";
 
 export async function getMana() {
   try {
@@ -238,6 +239,27 @@ export async function setNewsFeed(feed) {
     await AsyncStorage.setItem(NEWS_KEY, JSON.stringify(feed));
   } catch (e) {
     console.warn("Error guardando noticias en storage", e);
+  }
+}
+
+// [MB] Helpers de logros
+export async function getAchievementsState() {
+  try {
+    const value = await AsyncStorage.getItem(ACHIEVEMENTS_KEY);
+    if (value) {
+      return JSON.parse(value);
+    }
+  } catch (e) {
+    console.warn("Error leyendo logros de storage", e);
+  }
+  return { progress: {}, unlocked: {} };
+}
+
+export async function setAchievementsState(state) {
+  try {
+    await AsyncStorage.setItem(ACHIEVEMENTS_KEY, JSON.stringify(state));
+  } catch (e) {
+    console.warn("Error guardando logros en storage", e);
   }
 }
 


### PR DESCRIPTION
## Summary
- add ACHIEVEMENTS templates and storage helpers
- extend AppContext with achievement progress, events and claims
- show top achievements on Home and wire event dispatches

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689be6494c6c83279576fdad8195bc19