### PR TITLE
feat(inventory/modal): pantalla de Inventario completa con filtros y acciones

### DIFF
--- a/App.js
+++ b/App.js
@@ -7,6 +7,7 @@
 import React from "react";
 import { NavigationContainer } from "@react-navigation/native";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { Colors } from "./src/theme";
 
 import Footer from "./src/components/Footer";
@@ -14,25 +15,40 @@ import HomeScreen from "./src/screens/HomeScreen";
 import TasksScreen from "./src/screens/TasksScreen";
 import PlantScreen from "./src/screens/PlantScreen";
 import ProfileScreen from "./src/screens/ProfileScreen";
+import InventoryScreen from "./src/screens/InventoryScreen";
 import { AppProvider } from "./src/state/AppContext";
 
 const Tab = createBottomTabNavigator();
+const RootStack = createNativeStackNavigator();
+
+function Tabs() {
+  return (
+    <Tab.Navigator
+      initialRouteName="HomeScreen"
+      screenOptions={{ headerShown: false }}
+      tabBar={(props) => <Footer {...props} />}
+      sceneContainerStyle={{ backgroundColor: Colors.background }}
+    >
+      <Tab.Screen name="HomeScreen" component={HomeScreen} />
+      <Tab.Screen name="TasksScreen" component={TasksScreen} />
+      <Tab.Screen name="PlantScreen" component={PlantScreen} />
+      <Tab.Screen name="ProfileScreen" component={ProfileScreen} />
+    </Tab.Navigator>
+  );
+}
 
 export default function App() {
   return (
     <AppProvider>
       <NavigationContainer>
-        <Tab.Navigator
-          initialRouteName="HomeScreen"
-          screenOptions={{ headerShown: false }}
-          tabBar={(props) => <Footer {...props} />}
-          sceneContainerStyle={{ backgroundColor: Colors.background }}
-        >
-          <Tab.Screen name="HomeScreen" component={HomeScreen} />
-          <Tab.Screen name="TasksScreen" component={TasksScreen} />
-          <Tab.Screen name="PlantScreen" component={PlantScreen} />
-          <Tab.Screen name="ProfileScreen" component={ProfileScreen} />
-        </Tab.Navigator>
+        <RootStack.Navigator screenOptions={{ headerShown: false }}>
+          <RootStack.Screen name="Tabs" component={Tabs} />
+          <RootStack.Screen
+            name="InventoryModal"
+            component={InventoryScreen}
+            options={{ presentation: "modal", headerShown: false }}
+          />
+        </RootStack.Navigator>
       </NavigationContainer>
     </AppProvider>
   );

--- a/src/components/home/InventorySection.js
+++ b/src/components/home/InventorySection.js
@@ -6,6 +6,7 @@
 
 import React from "react";
 import { View, Text, Pressable, Alert } from "react-native";
+import { useNavigation } from "@react-navigation/native";
 import styles from "./InventorySection.styles";
 import {
   useAppState,
@@ -22,6 +23,7 @@ export default function InventorySection({ onShopPress }) {
   const counts = useInventoryCounts();
   const hydration = useHydrationStatus();
   const topItems = inventory.slice(0, 3);
+  const navigation = useNavigation();
 
   const handleUse = (item) => {
     const current = inventory.find((it) => it.sku === item.sku);
@@ -111,7 +113,7 @@ export default function InventorySection({ onShopPress }) {
       </View>
 
       <Pressable
-        onPress={() => {}}
+        onPress={() => navigation.navigate("InventoryModal")}
         style={styles.viewAllButton}
         accessibilityRole="button"
         accessibilityLabel="Ver inventario completo"

--- a/src/screens/InventoryScreen.js
+++ b/src/screens/InventoryScreen.js
@@ -1,0 +1,178 @@
+// [MB] Módulo: Inventario / Pantalla: InventoryScreen
+// Afecta: navegación modal de inventario
+// Propósito: Mostrar inventario completo con filtros y acciones
+// Puntos de edición futura: integrar nuevos ítems y paginación
+// Autor: Codex - Fecha: 2025-08-18
+
+import React, { useState, useMemo } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  Pressable,
+  TextInput,
+  Alert,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import styles from "./InventoryScreen.styles";
+import {
+  useAppState,
+  useAppDispatch,
+  useInventoryCounts,
+} from "../state/AppContext";
+import { Opacity, Colors, Spacing } from "../theme";
+
+const TABS = [
+  { key: "potions", label: "Pociones" },
+  { key: "tools", label: "Herramientas" },
+  { key: "cosmetics", label: "Cosméticos" },
+  { key: "all", label: "Todos" },
+];
+
+export default function InventoryScreen() {
+  const { inventory } = useAppState();
+  const dispatch = useAppDispatch();
+  const counts = useInventoryCounts();
+  const [tab, setTab] = useState("all");
+  const [query, setQuery] = useState("");
+
+  const filtered = useMemo(() => {
+    return inventory.filter((it) => {
+      const byTab = tab === "all" || it.category === tab;
+      const bySearch = it.title.toLowerCase().includes(query.toLowerCase());
+      return byTab && bySearch;
+    });
+  }, [inventory, tab, query]);
+
+  const handleUse = (item) => {
+    const current = inventory.find((it) => it.sku === item.sku);
+    if (!current || current.quantity <= 0) return;
+    dispatch({ type: "CONSUME_ITEM", payload: { sku: item.sku } });
+    if (item.sku === "shop/potions/p1") {
+      dispatch({
+        type: "ACTIVATE_BUFF",
+        payload: { type: "xp_double", durationMs: 2 * 60 * 60 * 1000 },
+      });
+      Alert.alert(
+        "Poción usada",
+        "Sabiduría activa: XP x2 por 2 horas"
+      );
+    } else if (item.sku === "shop/potions/p2") {
+      Alert.alert("Poción usada", "Cristal de Maná +100");
+    }
+  };
+
+  const handleDiscard = (item) => {
+    Alert.alert("Descartar", "¿Eliminar 1 unidad?", [
+      { text: "Cancelar", style: "cancel" },
+      {
+        text: "OK",
+        onPress: () =>
+          dispatch({ type: "DISCARD_ITEM", payload: { sku: item.sku } }),
+      },
+    ]);
+  };
+
+  const renderItem = ({ item }) => {
+    const isUsable =
+      item.category === "potions" &&
+      item.quantity > 0 &&
+      (item.sku === "shop/potions/p2" || item.sku === "shop/potions/p1");
+
+    return (
+      <View style={styles.itemRow}>
+        <View style={styles.itemHeader}>
+          <View style={styles.itemInfo}>
+            <Text style={styles.itemTitle}>{item.title}</Text>
+            <Text style={styles.itemSku}>{item.sku}</Text>
+          </View>
+          <Text style={styles.itemQty}>{`× ${item.quantity}`}</Text>
+        </View>
+        <View style={styles.actionsRow}>
+          <Pressable
+            onPress={() => handleUse(item)}
+            disabled={!isUsable}
+            style={[styles.useButton, !isUsable && { opacity: Opacity.disabled }]}
+            accessibilityRole="button"
+            accessibilityLabel={`Usar ${item.title}`}
+          >
+            <Text style={styles.useButtonText}>Usar</Text>
+          </Pressable>
+          <Pressable
+            onPress={() => handleDiscard(item)}
+            disabled={item.quantity <= 0}
+            style={[
+              styles.discardButton,
+              item.quantity <= 0 && { opacity: Opacity.disabled },
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel={`Descartar ${item.title}`}
+          >
+            <Text style={styles.discardButtonText}>Descartar</Text>
+          </Pressable>
+        </View>
+      </View>
+    );
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <FlatList
+        data={filtered}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        ListHeaderComponent={
+          <View>
+            <Text style={styles.title} accessibilityRole="header">
+              Inventario {counts.total}
+            </Text>
+            <Text style={styles.resultText}>{`Resultados: ${filtered.length}`}</Text>
+            <View style={styles.chipsRow}>
+              <View style={styles.chip}>
+                <Text style={styles.chipText}>Pociones {counts.potions}</Text>
+              </View>
+              <View style={styles.chip}>
+                <Text style={styles.chipText}>Herramientas {counts.tools}</Text>
+              </View>
+              <View style={styles.chip}>
+                <Text style={styles.chipText}>Cosméticos {counts.cosmetics}</Text>
+              </View>
+            </View>
+            <View style={styles.tabsRow}>
+              {TABS.map((t) => (
+                <Pressable
+                  key={t.key}
+                  onPress={() => setTab(t.key)}
+                  style={[
+                    styles.tabButton,
+                    tab === t.key && styles.tabButtonActive,
+                  ]}
+                  accessibilityRole="tab"
+                  accessibilityState={{ selected: tab === t.key }}
+                >
+                  <Text
+                    style={[
+                      styles.tabButtonText,
+                      tab === t.key && styles.tabButtonTextActive,
+                    ]}
+                  >
+                    {t.label}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+            <TextInput
+              style={styles.searchInput}
+              placeholder="Buscar"
+              placeholderTextColor={Colors.textMuted}
+              value={query}
+              onChangeText={setQuery}
+            />
+          </View>
+        }
+        contentContainerStyle={{ padding: Spacing.base, paddingBottom: 96 }}
+      />
+    </SafeAreaView>
+  );
+}
+

--- a/src/screens/InventoryScreen.styles.js
+++ b/src/screens/InventoryScreen.styles.js
@@ -1,0 +1,131 @@
+// [MB] Módulo: Inventario / Pantalla: InventoryScreen (Estilos)
+// Afecta: pantalla modal de inventario
+// Propósito: Estilos para la lista completa de inventario
+// Puntos de edición futura: colores por categoría y layout responsivo
+// Autor: Codex - Fecha: 2025-08-18
+
+import { StyleSheet } from "react-native";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Typography,
+  Elevation,
+} from "../theme";
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.background,
+  },
+  title: {
+    ...Typography.h2,
+    color: Colors.text,
+  },
+  resultText: {
+    ...Typography.caption,
+    color: Colors.textMuted,
+    marginTop: Spacing.tiny,
+  },
+  chipsRow: {
+    flexDirection: "row",
+    marginTop: Spacing.small,
+  },
+  chip: {
+    backgroundColor: Colors.surfaceElevated,
+    borderRadius: Radii.pill,
+    paddingHorizontal: Spacing.base,
+    height: 28,
+    justifyContent: "center",
+    marginRight: Spacing.small,
+  },
+  chipText: {
+    ...Typography.caption,
+    color: Colors.text,
+  },
+  tabsRow: {
+    flexDirection: "row",
+    marginTop: Spacing.base,
+  },
+  tabButton: {
+    flex: 1,
+    paddingVertical: Spacing.small,
+    backgroundColor: Colors.surfaceElevated,
+    borderRadius: Radii.md,
+    alignItems: "center",
+    marginRight: Spacing.small,
+  },
+  tabButtonActive: {
+    backgroundColor: Colors.primary,
+  },
+  tabButtonText: {
+    ...Typography.body,
+    color: Colors.text,
+  },
+  tabButtonTextActive: {
+    color: Colors.textInverse,
+  },
+  searchInput: {
+    marginTop: Spacing.base,
+    backgroundColor: Colors.surfaceElevated,
+    borderRadius: Radii.md,
+    paddingHorizontal: Spacing.base,
+    paddingVertical: Spacing.small,
+    color: Colors.text,
+  },
+  itemRow: {
+    backgroundColor: Colors.surfaceElevated,
+    borderRadius: Radii.lg,
+    padding: Spacing.base,
+    marginBottom: Spacing.small,
+    ...Elevation.card,
+  },
+  itemHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: Spacing.small,
+  },
+  itemInfo: {
+    flex: 1,
+  },
+  itemTitle: {
+    ...Typography.body,
+    color: Colors.text,
+  },
+  itemSku: {
+    ...Typography.caption,
+    color: Colors.textMuted,
+  },
+  itemQty: {
+    ...Typography.body,
+    color: Colors.text,
+    marginLeft: Spacing.small,
+  },
+  actionsRow: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+  },
+  useButton: {
+    backgroundColor: Colors.buttonBg,
+    paddingHorizontal: Spacing.small,
+    paddingVertical: Spacing.tiny,
+    borderRadius: Radii.sm,
+    marginRight: Spacing.small,
+  },
+  useButtonText: {
+    ...Typography.caption,
+    color: Colors.textInverse,
+  },
+  discardButton: {
+    backgroundColor: Colors.danger,
+    paddingHorizontal: Spacing.small,
+    paddingVertical: Spacing.tiny,
+    borderRadius: Radii.sm,
+  },
+  discardButtonText: {
+    ...Typography.caption,
+    color: Colors.textInverse,
+  },
+});
+

--- a/src/state/AppContext.js
+++ b/src/state/AppContext.js
@@ -372,6 +372,19 @@ function appReducer(state, action) {
         .filter((it) => it.quantity > 0);
       return { ...state, mana, inventory };
     }
+    case "DISCARD_ITEM": {
+      const { sku } = action.payload;
+      const item = state.inventory.find((it) => it.sku === sku);
+      if (!item || item.quantity <= 0) {
+        return state;
+      }
+      const inventory = state.inventory
+        .map((it) =>
+          it.sku === sku ? { ...it, quantity: it.quantity - 1 } : it
+        )
+        .filter((it) => it.quantity > 0);
+      return { ...state, inventory };
+    }
     case "ACHIEVEMENT_EVENT": {
       const { type, payload } = action.payload;
       const progress = { ...state.achievements.progress };


### PR DESCRIPTION
## Summary
- add full Inventory modal with category tabs, search, use and discard actions
- enable "Ver todo" to open InventoryModal
- support DISCARD_ITEM in state reducer and wire root stack navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689be8e9a55c83279d9e88661e32139e