### PR TITLE
feat(news/inbox): bandeja de noticias modal con detalle y marcado de lectura

### DIFF
--- a/App.js
+++ b/App.js
@@ -2,7 +2,7 @@
 // Afecta: navegación global
 // Propósito: Configurar navegación y proveer contexto global
 // Puntos de edición futura: agregar providers adicionales
-// Autor: Codex - Fecha: 2025-08-12
+// Autor: Codex - Fecha: 2025-08-13
 
 import React from "react";
 import { NavigationContainer } from "@react-navigation/native";
@@ -53,8 +53,7 @@ export default function App() {
           <RootStack.Screen
             name="NewsInboxModal"
             component={NewsInboxScreen}
-            options={{ presentation: "modal" }}
-
+            options={{ presentation: "modal", headerShown: false }}
           />
         </RootStack.Navigator>
       </NavigationContainer>

--- a/src/components/home/NewsFeedSection.js
+++ b/src/components/home/NewsFeedSection.js
@@ -7,35 +7,17 @@
 import React from "react";
 import { View, Text, TouchableOpacity } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+import { useNavigation } from "@react-navigation/native";
 import { Colors } from "../../theme";
 import styles from "./NewsFeedSection.styles";
-import {
-  useNewsFeed,
-  useAppDispatch,
-  useHydrationStatus,
-} from "../../state/AppContext";
+import { useNewsFeed, useHydrationStatus } from "../../state/AppContext";
+import { timeAgo } from "../../utils/time";
 import SectionPlaceholder from "./SectionPlaceholder";
-
-function timeAgo(iso) {
-  const diffMs = Date.now() - new Date(iso).getTime();
-  const m = Math.floor(diffMs / 60000);
-  const h = Math.floor(m / 60);
-  const d = Math.floor(h / 24);
-  if (m < 60) return `hace ${m} min`;
-  if (h < 24) return `hace ${h} h`;
-  if (d === 1) return "ayer";
-  return `hace ${d} días`;
-}
 
 export default function NewsFeedSection() {
   const { items } = useNewsFeed();
-  const dispatch = useAppDispatch();
+  const navigation = useNavigation();
   const hydration = useHydrationStatus();
-
-  const markAll = () => dispatch({ type: "MARK_ALL_NEWS_READ" });
-  const handlePress = (id) => {
-    dispatch({ type: "MARK_NEWS_READ", payload: { id } });
-  };
 
   if (hydration.news) {
     return <SectionPlaceholder height={220} />;
@@ -48,11 +30,11 @@ export default function NewsFeedSection() {
           Noticias
         </Text>
         <TouchableOpacity
-          onPress={markAll}
+          onPress={() => navigation.navigate("NewsInboxModal")}
           accessibilityRole="button"
-          accessibilityLabel="Marcar todas las noticias como leídas"
+          accessibilityLabel="Ver todas las noticias"
         >
-          <Text style={styles.markAll}>Marcar todo como leído</Text>
+          <Text style={styles.viewAll}>Ver todo</Text>
         </TouchableOpacity>
       </View>
       {items.length === 0 ? (
@@ -62,9 +44,11 @@ export default function NewsFeedSection() {
           <TouchableOpacity
             key={item.id}
             style={styles.row}
-            onPress={() => handlePress(item.id)}
+            onPress={() =>
+              navigation.navigate("NewsInboxModal", { initialId: item.id })
+            }
             accessibilityRole="button"
-            accessibilityLabel={`Marcar ${item.title} como leído`}
+            accessibilityLabel={`Abrir noticia: ${item.title}`}
           >
             <Ionicons name={item.iconName} size={20} color={Colors.text} />
             <View style={styles.rowText}>

--- a/src/components/home/NewsFeedSection.styles.js
+++ b/src/components/home/NewsFeedSection.styles.js
@@ -1,8 +1,8 @@
 // [MB] Módulo: Home / Estilos: NewsFeedSection
 // Afecta: HomeScreen
-// Propósito: Estilos para feed de noticias con marcas de leído
+// Propósito: Estilos para feed de noticias con acceso a la bandeja completa
 // Puntos de edición futura: ajustar layout y variantes de ítems
-// Autor: Codex - Fecha: 2025-08-12
+// Autor: Codex - Fecha: 2025-08-13
 
 import { StyleSheet } from "react-native";
 import { Colors, Spacing, Radii, Elevation, Typography } from "../../theme";
@@ -25,7 +25,7 @@ export default StyleSheet.create({
     ...Typography.h2,
     color: Colors.text,
   },
-  markAll: {
+  viewAll: {
     ...Typography.caption,
     color: Colors.accent,
   },

--- a/src/components/news/NewsDetailModal.js
+++ b/src/components/news/NewsDetailModal.js
@@ -1,0 +1,92 @@
+// [MB] Módulo: Noticias / Componente: NewsDetailModal
+// Afecta: NewsInboxScreen
+// Propósito: Mostrar detalle de una noticia con acciones de lectura
+// Puntos de edición futura: conectar cuerpo real y animaciones
+// Autor: Codex - Fecha: 2025-08-13
+
+import React, { useEffect, useRef } from "react";
+import {
+  Modal,
+  View,
+  Text,
+  TouchableOpacity,
+  AccessibilityInfo,
+  findNodeHandle,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useAppDispatch } from "../../state/AppContext";
+import { Colors } from "../../theme";
+import styles from "./NewsDetailModal.styles";
+
+export default function NewsDetailModal({ news, onClose }) {
+  const dispatch = useAppDispatch();
+  const titleRef = useRef(null);
+
+  useEffect(() => {
+    if (!news.read) {
+      dispatch({ type: "MARK_NEWS_READ", payload: { id: news.id } });
+    }
+    const node = findNodeHandle(titleRef.current);
+    if (node) {
+      AccessibilityInfo.setAccessibilityFocus(node);
+    }
+  }, [news, dispatch]);
+
+  const handleMark = () => {
+    dispatch({ type: "MARK_NEWS_READ", payload: { id: news.id } });
+    onClose();
+  };
+
+  const formattedDate = new Date(news.timestamp).toLocaleDateString("es-ES");
+
+  return (
+    <Modal
+      visible
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <View style={styles.content} accessibilityRole="dialog">
+          <Ionicons
+            name={news.iconName}
+            size={48}
+            color={Colors.text}
+            style={styles.icon}
+          />
+          <Text ref={titleRef} style={styles.title} accessibilityRole="header">
+            {news.title}
+          </Text>
+          <Text style={styles.date}>{formattedDate}</Text>
+          <Text style={styles.body} accessibilityRole="text">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            Vestibulum id ligula porta felis euismod semper.
+            Donec id elit non mi porta gravida at eget metus.
+
+            Sed posuere consectetur est at lobortis. Maecenas faucibus
+            mollis interdum. Integer posuere erat a ante venenatis dapibus.
+
+            Cras mattis consectetur purus sit amet fermentum. Praesent
+            commodo cursus magna, vel scelerisque nisl consectetur et.
+          </Text>
+          <View style={styles.actions}>
+            <TouchableOpacity
+              onPress={onClose}
+              accessibilityRole="button"
+              accessibilityLabel="Cerrar detalle de noticia"
+            >
+              <Text style={styles.actionText}>Cerrar</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={handleMark}
+              accessibilityRole="button"
+              accessibilityLabel="Marcar noticia como leída"
+            >
+              <Text style={styles.actionText}>Marcar leído</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/src/components/news/NewsDetailModal.styles.js
+++ b/src/components/news/NewsDetailModal.styles.js
@@ -1,0 +1,54 @@
+// [MB] Módulo: Noticias / Estilos: NewsDetailModal
+// Afecta: NewsDetailModal
+// Propósito: Estilos para overlay de detalle de noticia
+// Puntos de edición futura: animaciones y tamaños responsivos
+// Autor: Codex - Fecha: 2025-08-13
+
+import { StyleSheet } from "react-native";
+import { Colors, Spacing, Radii, Typography, Elevation } from "../../theme";
+
+export default StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: Colors.overlay,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: Spacing.base,
+  },
+  content: {
+    width: "100%",
+    backgroundColor: Colors.surface,
+    borderRadius: Radii.lg,
+    padding: Spacing.large,
+    gap: Spacing.small,
+    ...Elevation.card,
+  },
+  icon: {
+    alignSelf: "center",
+  },
+  title: {
+    ...Typography.h2,
+    color: Colors.text,
+    textAlign: "center",
+  },
+  date: {
+    ...Typography.caption,
+    color: Colors.textMuted,
+    textAlign: "center",
+  },
+  body: {
+    ...Typography.body,
+    color: Colors.text,
+    marginTop: Spacing.small,
+  },
+  actions: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginTop: Spacing.large,
+    gap: Spacing.base,
+  },
+  actionText: {
+    ...Typography.body,
+    color: Colors.accent,
+  },
+});

--- a/src/screens/NewsInboxScreen.js
+++ b/src/screens/NewsInboxScreen.js
@@ -1,19 +1,120 @@
 // [MB] Módulo: Noticias / Pantalla: NewsInboxScreen
-// Afecta: HomeScreen (modal de noticias)
-// Propósito: mostrar bandeja de noticias
-// Puntos de edición futura: estilos dedicados y conexión real
-// Autor: Codex - Fecha: 2025-08-19
+// Afecta: NewsInboxModal
+// Propósito: Bandeja de noticias con filtros y detalle
+// Puntos de edición futura: conectar con feed real y paginación
+// Autor: Codex - Fecha: 2025-08-13
 
-import React from "react";
-import { SafeAreaView, Text } from "react-native";
+import React, { useState, useEffect } from "react";
+import {
+  SafeAreaView,
+  View,
+  Text,
+  TouchableOpacity,
+  FlatList,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useRoute } from "@react-navigation/native";
+import { useNewsFeed, useAppDispatch } from "../state/AppContext";
 import { Colors, Spacing } from "../theme";
+import { timeAgo } from "../utils/time";
+import styles from "./NewsInboxScreen.styles";
+import NewsDetailModal from "../components/news/NewsDetailModal";
 
 export default function NewsInboxScreen() {
-  return (
-    <SafeAreaView
-      style={{ flex: 1, backgroundColor: Colors.background, padding: Spacing.base }}
+  const { items } = useNewsFeed();
+  const dispatch = useAppDispatch();
+  const route = useRoute();
+  const [filter, setFilter] = useState("all");
+  const [selected, setSelected] = useState(null);
+
+  const filteredItems =
+    filter === "unread" ? items.filter((it) => !it.read) : items;
+
+  const markAll = () => dispatch({ type: "MARK_ALL_NEWS_READ" });
+
+  useEffect(() => {
+    const initialId = route.params?.initialId;
+    if (initialId) {
+      const found = items.find((it) => it.id === initialId);
+      if (found) setSelected(found);
+    }
+  }, [route.params, items]);
+
+  const renderItem = ({ item }) => (
+    <TouchableOpacity
+      style={styles.row}
+      onPress={() => setSelected(item)}
+      accessibilityRole="button"
+      accessibilityLabel={`Abrir noticia: ${item.title}`}
     >
-      <Text style={{ color: Colors.text }}>Bandeja de noticias</Text>
+      <Ionicons name={item.iconName} size={24} color={Colors.text} />
+      <View style={styles.rowText}>
+        <Text style={styles.rowTitle}>{item.title}</Text>
+        <Text style={styles.time}>{timeAgo(item.timestamp)}</Text>
+      </View>
+      {!item.read && <View style={styles.unreadDot} />}
+    </TouchableOpacity>
+  );
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <FlatList
+        data={filteredItems}
+        keyExtractor={(it) => it.id}
+        renderItem={renderItem}
+        contentContainerStyle={{
+          padding: Spacing.base,
+          paddingBottom: 96,
+          gap: Spacing.small,
+        }}
+        ListHeaderComponent={
+          <View style={styles.headerWrapper}>
+            <View style={styles.headerRow}>
+              <Text style={styles.title} accessibilityRole="header">
+                Bandeja de noticias
+              </Text>
+              <TouchableOpacity
+                onPress={markAll}
+                accessibilityRole="button"
+                accessibilityLabel="Marcar todas las noticias como leídas"
+              >
+                <Text style={styles.markAll}>Marcar todo leído</Text>
+              </TouchableOpacity>
+            </View>
+            <View style={styles.filterRow}>
+              <TouchableOpacity
+                onPress={() => setFilter("all")}
+                accessibilityRole="button"
+                accessibilityLabel="Mostrar todas las noticias"
+              >
+                <Text
+                  style={filter === "all" ? styles.filterActive : styles.filter}
+                >
+                  Todos
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={() => setFilter("unread")}
+                accessibilityRole="button"
+                accessibilityLabel="Mostrar noticias no leídas"
+              >
+                <Text
+                  style={filter === "unread" ? styles.filterActive : styles.filter}
+                >
+                  No leídos
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        }
+        accessibilityRole="list"
+      />
+      {selected && (
+        <NewsDetailModal
+          news={selected}
+          onClose={() => setSelected(null)}
+        />
+      )}
     </SafeAreaView>
   );
 }

--- a/src/screens/NewsInboxScreen.styles.js
+++ b/src/screens/NewsInboxScreen.styles.js
@@ -1,0 +1,68 @@
+// [MB] Módulo: Noticias / Estilos: NewsInboxScreen
+// Afecta: NewsInboxModal
+// Propósito: Estilos para bandeja de noticias con filtros y detalle
+// Puntos de edición futura: variaciones de layout y colores
+// Autor: Codex - Fecha: 2025-08-13
+
+import { StyleSheet } from "react-native";
+import { Colors, Spacing, Radii, Typography, Elevation } from "../theme";
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.background,
+  },
+  headerWrapper: {
+    marginBottom: Spacing.small,
+    gap: Spacing.small,
+  },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  title: {
+    ...Typography.h1,
+    color: Colors.text,
+  },
+  markAll: {
+    ...Typography.caption,
+    color: Colors.accent,
+  },
+  filterRow: {
+    flexDirection: "row",
+    gap: Spacing.base,
+  },
+  filter: {
+    ...Typography.body,
+    color: Colors.textMuted,
+  },
+  filterActive: {
+    ...Typography.body,
+    color: Colors.text,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.small,
+    backgroundColor: Colors.surface,
+    padding: Spacing.base,
+    borderRadius: Radii.md,
+    ...Elevation.card,
+  },
+  rowText: { flex: 1 },
+  rowTitle: {
+    ...Typography.body,
+    color: Colors.text,
+  },
+  time: {
+    ...Typography.caption,
+    color: Colors.textMuted,
+  },
+  unreadDot: {
+    width: 8,
+    height: 8,
+    borderRadius: Radii.pill,
+    backgroundColor: Colors.accent,
+  },
+});

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -1,0 +1,16 @@
+// [MB] Módulo: Utils / Archivo: time
+// Afecta: NewsFeedSection, NewsInboxScreen
+// Propósito: Utilidad para mostrar tiempo relativo en noticias
+// Puntos de edición futura: internacionalización y traducciones
+// Autor: Codex - Fecha: 2025-08-13
+
+export function timeAgo(iso) {
+  const ms = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(ms / 60000);
+  const h = Math.floor(m / 60);
+  const d = Math.floor(h / 24);
+  if (m < 60) return `hace ${m} min`;
+  if (h < 24) return `hace ${h} h`;
+  if (d === 1) return "ayer";
+  return `hace ${d} días`;
+}


### PR DESCRIPTION
## Summary
- add reusable `timeAgo` util
- implement `NewsInboxScreen` modal with filters, mark-all, and detail overlay
- wire home news section to open the inbox modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bf2c09eac832786be356fa9a5622d