### PR TITLE
feat(profile/achievements): move achievements to profile and add toast

### DIFF
--- a/src/components/common/AchievementToast.js
+++ b/src/components/common/AchievementToast.js
@@ -1,0 +1,42 @@
+// [MB] Módulo: Common / Sección: AchievementToast
+// Afecta: HomeScreen, ProfileScreen
+// Propósito: Mostrar toast cuando se desbloquea un logro
+// Puntos de edición futura: animaciones, temas y posicionamiento
+// Autor: Codex - Fecha: 2025-08-13
+
+import React, { useEffect } from "react";
+import { View, Text, Pressable } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import styles from "./AchievementToast.styles";
+
+export default function AchievementToast({ visible, title, onClose }) {
+  const insets = useSafeAreaInsets();
+
+  useEffect(() => {
+    if (visible) {
+      const t = setTimeout(onClose, 5000);
+      return () => clearTimeout(t);
+    }
+  }, [visible, onClose]);
+
+  if (!visible) return null;
+
+  return (
+    <View
+      style={[styles.container, { top: insets.top + 8 }]}
+      accessibilityRole="alert"
+    >
+      <Text style={styles.icon}>🏆</Text>
+      <Text style={styles.text}>¡Logro desbloqueado! {title}</Text>
+      <Pressable
+        onPress={onClose}
+        style={styles.closeButton}
+        accessibilityRole="button"
+        accessibilityLabel="Cerrar notificación de logro"
+      >
+        <Text style={styles.closeText}>✕</Text>
+      </Pressable>
+    </View>
+  );
+}
+

--- a/src/components/common/AchievementToast.styles.js
+++ b/src/components/common/AchievementToast.styles.js
@@ -1,0 +1,39 @@
+// [MB] Módulo: Common / Estilos: AchievementToast
+// Afecta: AchievementToast
+// Propósito: Estilos para toast de logro desbloqueado
+// Puntos de edición futura: animaciones y paleta
+// Autor: Codex - Fecha: 2025-08-13
+
+import { StyleSheet } from "react-native";
+import { Colors, Spacing, Radii, Typography, Elevation } from "../../theme";
+
+export default StyleSheet.create({
+  container: {
+    position: "absolute",
+    left: Spacing.base,
+    right: Spacing.base,
+    padding: Spacing.base,
+    borderRadius: Radii.lg,
+    backgroundColor: Colors.surfaceElevated,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.small,
+    ...Elevation.card,
+  },
+  icon: {
+    fontSize: 20,
+  },
+  text: {
+    ...Typography.body,
+    color: Colors.text,
+    flex: 1,
+  },
+  closeButton: {
+    padding: Spacing.tiny,
+  },
+  closeText: {
+    ...Typography.body,
+    color: Colors.text,
+  },
+});
+

--- a/src/components/profile/AchievementsPanel.js
+++ b/src/components/profile/AchievementsPanel.js
@@ -1,0 +1,94 @@
+// [MB] Módulo: Profile / Sección: AchievementsPanel
+// Afecta: ProfileScreen
+// Propósito: Mostrar logros listos para reclamar y en progreso en el perfil
+// Puntos de edición futura: navegación a listado completo y estilos adicionales
+// Autor: Codex - Fecha: 2025-08-13
+
+import React from "react";
+import { View, Text, Pressable } from "react-native";
+import styles from "./AchievementsPanel.styles";
+import { useAppState, useAppDispatch, useHydrationStatus } from "../../state/AppContext";
+import { ACHIEVEMENTS } from "../../constants/achievements";
+import SectionPlaceholder from "../home/SectionPlaceholder";
+
+export default function AchievementsPanel() {
+  const { achievements, level, streak } = useAppState();
+  const dispatch = useAppDispatch();
+  const hydration = useHydrationStatus();
+
+  if (hydration.achievements) {
+    return <SectionPlaceholder height={220} />;
+  }
+
+  const list = ACHIEVEMENTS.map((a) => {
+    let progress = 0;
+    if (a.type === "count_event") {
+      progress = achievements.progress[a.id]?.count || 0;
+    } else if (a.type === "window_count") {
+      progress = achievements.progress[a.id]?.timestamps?.length || 0;
+    } else if (a.type === "reach_value") {
+      progress = a.metric === "level" ? level : streak;
+    }
+    const unlocked = !!achievements.unlocked[a.id];
+    const claimed = achievements.unlocked[a.id]?.claimed;
+    return { ...a, progress, unlocked, claimed };
+  });
+
+  const unclaimed = list.filter((a) => a.unlocked && !a.claimed);
+  const inProgress = list
+    .filter((a) => !a.unlocked)
+    .sort((a, b) => b.progress / b.goal - a.progress / a.goal);
+  const claimed = list.filter((a) => a.claimed);
+  const combined = [...unclaimed, ...inProgress, ...claimed];
+
+  const handleClaim = (id) => {
+    dispatch({ type: "CLAIM_ACHIEVEMENT", payload: { id } });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title} accessibilityRole="header">Logros</Text>
+      {combined.map((ach) => {
+        const progressPct = Math.min(1, ach.progress / ach.goal);
+        const progressText = `${Math.min(ach.progress, ach.goal)}/${ach.goal}`;
+        const canClaim = ach.unlocked && !ach.claimed;
+        const status = canClaim
+          ? "Listo para reclamar"
+          : ach.claimed
+          ? "Reclamado"
+          : "En progreso";
+        return (
+          <View key={ach.id} style={styles.card}>
+            <Text style={styles.achievementTitle}>{ach.title}</Text>
+            <View style={styles.progressBar}>
+              <View
+                style={[styles.progressFill, { width: `${progressPct * 100}%` }]}
+              />
+            </View>
+            <Text style={styles.progressText}>{progressText}</Text>
+            {canClaim && (
+              <Pressable
+                onPress={() => handleClaim(ach.id)}
+                style={styles.claimButton}
+                accessibilityRole="button"
+                accessibilityLabel={`Reclamar logro ${ach.title}`}
+              >
+                <Text style={styles.claimButtonText}>Reclamar</Text>
+              </Pressable>
+            )}
+            <Text style={styles.statusText}>{status}</Text>
+          </View>
+        );
+      })}
+      <Pressable
+        onPress={() => {}}
+        style={styles.viewAllButton}
+        accessibilityRole="button"
+        accessibilityLabel="Ver todos los logros"
+      >
+        <Text style={styles.viewAllText}>Ver todos</Text>
+      </Pressable>
+    </View>
+  );
+}
+

--- a/src/components/profile/AchievementsPanel.styles.js
+++ b/src/components/profile/AchievementsPanel.styles.js
@@ -1,0 +1,78 @@
+// [MB] Módulo: Profile / Estilos: AchievementsPanel
+// Afecta: AchievementsPanel
+// Propósito: Estilos para panel de logros en perfil
+// Puntos de edición futura: ajuste de colores y disposición
+// Autor: Codex - Fecha: 2025-08-13
+
+import { StyleSheet } from "react-native";
+import { Colors, Spacing, Radii, Typography, Elevation } from "../../theme";
+
+export default StyleSheet.create({
+  container: {
+    backgroundColor: Colors.surface,
+    padding: Spacing.base,
+    borderRadius: Radii.md,
+    marginBottom: Spacing.tiny,
+    ...Elevation.card,
+  },
+  title: {
+    ...Typography.h2,
+    color: Colors.text,
+  },
+  card: {
+    backgroundColor: Colors.surfaceAlt,
+    padding: Spacing.base,
+    borderRadius: Radii.md,
+    marginTop: Spacing.tiny,
+  },
+  achievementTitle: {
+    ...Typography.body,
+    color: Colors.text,
+    marginBottom: Spacing.small,
+  },
+  progressBar: {
+    height: 6,
+    backgroundColor: Colors.border,
+    borderRadius: Radii.pill,
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    backgroundColor: Colors.secondary,
+    borderRadius: Radii.pill,
+  },
+  progressText: {
+    ...Typography.caption,
+    color: Colors.textMuted,
+    marginTop: Spacing.tiny,
+  },
+  claimButton: {
+    marginTop: Spacing.small,
+    paddingVertical: Spacing.small,
+    borderRadius: Radii.md,
+    alignItems: "center",
+    backgroundColor: Colors.buttonBg,
+  },
+  claimButtonText: {
+    ...Typography.body,
+    color: Colors.textInverse,
+  },
+  statusText: {
+    ...Typography.caption,
+    color: Colors.text,
+    marginTop: Spacing.small,
+  },
+  viewAllButton: {
+    marginTop: Spacing.base,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: Radii.md,
+    paddingVertical: Spacing.small,
+    alignItems: "center",
+  },
+  viewAllText: {
+    ...Typography.body,
+    color: Colors.text,
+  },
+});
+

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -12,16 +12,22 @@ import HomeScreenHeader from "../components/HomeScreenHeader";
 import HomeWelcomeCard from "../components/home/HomeWelcomeCard";
 import DailyRewardSection from "../components/home/DailyRewardSection";
 import DailyChallengesSection from "../components/home/DailyChallengesSection";
-import AchievementsSection from "../components/home/AchievementsSection";
 import MagicShopSection from "../components/home/MagicShopSection";
 import InventorySection from "../components/home/InventorySection";
 import NewsFeedSection from "../components/home/NewsFeedSection";
 import StatsQuickTiles from "../components/home/StatsQuickTiles";
 import EventBanner from "../components/home/EventBanner";
-import { useAppState } from "../state/AppContext";
+import AchievementToast from "../components/common/AchievementToast";
+import {
+  useAppState,
+  useAppDispatch,
+  useAchievementToast,
+} from "../state/AppContext";
 
 export default function HomeScreen() {
   const { mana, plantState } = useAppState();
+  const achievementToast = useAchievementToast();
+  const dispatch = useAppDispatch();
   const scrollRef = useRef(null);
   const [shopY, setShopY] = useState(0);
 
@@ -31,6 +37,13 @@ export default function HomeScreen() {
 
   return (
     <SafeAreaView style={styles.container}>
+      {achievementToast && (
+        <AchievementToast
+          visible
+          title={achievementToast.title}
+          onClose={() => dispatch({ type: "CLEAR_ACHIEVEMENT_TOAST" })}
+        />
+      )}
       <HomeScreenHeader userName="Jugador" manaCount={mana} plantState={plantState} />
       <ScrollView
         ref={scrollRef}
@@ -44,7 +57,6 @@ export default function HomeScreen() {
         <HomeWelcomeCard />
         <DailyRewardSection />
         <DailyChallengesSection />
-        <AchievementsSection />
         <MagicShopSection onLayout={handleShopLayout} />
         <InventorySection onShopPress={scrollToShop} />
         <NewsFeedSection />

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -1,24 +1,51 @@
+// [MB] Módulo: Profile / Sección: ProfileScreen
+// Afecta: ProfileScreen (pantalla de perfil)
+// Propósito: Mostrar información del perfil y panel de logros
+// Puntos de edición futura: agregar más secciones y navegación
+// Autor: Codex - Fecha: 2025-08-13
+
 import React from "react";
-import { View, Text, StyleSheet } from "react-native";
-import { Colors } from "../theme";
+import { View, Text, StyleSheet, ScrollView } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Colors, Spacing, Typography } from "../theme";
+import AchievementsPanel from "../components/profile/AchievementsPanel";
+import AchievementToast from "../components/common/AchievementToast";
+import { useAchievementToast, useAppDispatch } from "../state/AppContext";
 
 export default function ProfileScreen() {
+  const achievementToast = useAchievementToast();
+  const dispatch = useAppDispatch();
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.text}>Perfil</Text>
-    </View>
+    <SafeAreaView style={styles.container}>
+      {achievementToast && (
+        <AchievementToast
+          visible
+          title={achievementToast.title}
+          onClose={() => dispatch({ type: "CLEAR_ACHIEVEMENT_TOAST" })}
+        />
+      )}
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.header} accessibilityRole="header">
+          Perfil
+        </Text>
+        <AchievementsPanel />
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
     backgroundColor: Colors.background,
   },
-  text: {
+  content: {
+    padding: Spacing.base,
+    gap: Spacing.large,
+  },
+  header: {
+    ...Typography.h1,
     color: Colors.text,
-    fontSize: 16,
   },
 });


### PR DESCRIPTION
## Summary
- move achievements panel from Home to Profile with claim and progress
- add global AchievementToast and state to show unlocked achievements
- remove Home achievements section and render toast on Home/Profile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bf77f0c9c83279cbcadc58fc53f9a