### PR TITLE
feat(home/header): mostrar monedas y diamantes junto a maná

### DIFF
--- a/src/components/HomeScreenHeader.js
+++ b/src/components/HomeScreenHeader.js
@@ -1,3 +1,9 @@
+// [MB] Módulo: Home / Sección: Encabezado
+// Afecta: HomeScreen (encabezado principal)
+// Propósito: Mostrar saludo, estado de planta y recursos
+// Puntos de edición futura: estilos y hooks en HomeScreenHeader.styles.js
+// Autor: Codex - Fecha: 2025-08-13
+
 import React from "react";
 import { View, Text } from "react-native";
 import { FontAwesome5, Ionicons } from "@expo/vector-icons";
@@ -5,13 +11,19 @@ import { LinearGradient } from "expo-linear-gradient";
 
 import styles from "./HomeScreenHeader.styles";
 import { Colors } from "../theme";
+import { useAppState, useWallet } from "../state/AppContext";
 
-export default function HomeScreenHeader({ userName, manaCount, plantState }) {
+export default function HomeScreenHeader({ userName }) {
+  const { mana, plantState } = useAppState();
+  const { coin, gem } = useWallet();
+
   return (
     <View style={styles.container}>
-      <Text style={styles.greeting}>¡Hola, {userName}!</Text>
-      <View style={styles.statusContainer}>
-        <View style={styles.statusItem}>
+      <View>
+        <Text style={styles.greeting} accessibilityRole="header">
+          ¡Hola, {userName}!
+        </Text>
+        <View style={styles.plantStatus}>
           <LinearGradient
             colors={[Colors.primary, Colors.secondary]}
             style={styles.iconBackground}
@@ -20,14 +32,31 @@ export default function HomeScreenHeader({ userName, manaCount, plantState }) {
           </LinearGradient>
           <Text style={styles.statusText}>{plantState}</Text>
         </View>
-        <View style={styles.statusItem}>
-          <LinearGradient
-            colors={[Colors.secondary, Colors.primary]}
-            style={styles.iconBackground}
-          >
-            <Ionicons name="flash" size={14} color={Colors.text} />
-          </LinearGradient>
-          <Text style={styles.statusText}>{manaCount}</Text>
+      </View>
+      <View style={styles.statusContainer}>
+        <View
+          style={styles.pill}
+          accessibilityRole="text"
+          accessibilityLabel={`Maná disponible: ${mana}`}
+        >
+          <Ionicons name="sparkles" size={14} color={Colors.text} />
+          <Text style={styles.pillText}>{mana}</Text>
+        </View>
+        <View
+          style={styles.pill}
+          accessibilityRole="text"
+          accessibilityLabel={`Monedas disponibles: ${coin}`}
+        >
+          <Ionicons name="pricetag" size={14} color={Colors.text} />
+          <Text style={styles.pillText}>{coin}</Text>
+        </View>
+        <View
+          style={styles.pill}
+          accessibilityRole="text"
+          accessibilityLabel={`Diamantes disponibles: ${gem}`}
+        >
+          <Ionicons name="diamond" size={14} color={Colors.text} />
+          <Text style={styles.pillText}>{gem}</Text>
         </View>
       </View>
     </View>

--- a/src/components/HomeScreenHeader.styles.js
+++ b/src/components/HomeScreenHeader.styles.js
@@ -1,5 +1,11 @@
+// [MB] Módulo: Home / Sección: Encabezado
+// Afecta: HomeScreenHeader
+// Propósito: Estilos para saludo y pills de recursos
+// Puntos de edición futura: ajustar tokens y responsive wrap
+// Autor: Codex - Fecha: 2025-08-13
+
 import { StyleSheet } from "react-native";
-import { Colors, Spacing } from "../theme";
+import { Colors, Spacing, Radii, Typography } from "../theme";
 
 export default StyleSheet.create({
   container: {
@@ -15,14 +21,10 @@ export default StyleSheet.create({
     fontWeight: "bold",
     color: Colors.text,
   },
-  statusContainer: {
+  plantStatus: {
     flexDirection: "row",
     alignItems: "center",
-  },
-  statusItem: {
-    flexDirection: "row",
-    alignItems: "center",
-    marginLeft: Spacing.base,
+    marginTop: Spacing.small,
   },
   iconBackground: {
     padding: Spacing.tiny,
@@ -32,5 +34,27 @@ export default StyleSheet.create({
   statusText: {
     color: Colors.text,
     fontSize: 16,
+  },
+  statusContainer: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "center",
+    columnGap: Spacing.tiny,
+    rowGap: Spacing.tiny,
+  },
+  pill: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: Colors.surfaceElevated || Colors.surface,
+    borderColor: `${Colors.accent}55`,
+    borderWidth: 1,
+    borderRadius: Radii.pill,
+    paddingHorizontal: Spacing.base,
+    height: 28,
+    gap: Spacing.tiny,
+  },
+  pillText: {
+    ...Typography.caption,
+    color: Colors.text,
   },
 });


### PR DESCRIPTION
## Summary
- leer wallet del contexto y mostrar coin/gem
- pills de maná, monedas y diamantes con a11y

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bfa0748088327a8ef2e5071de096d