### PR TITLE
feat(shop/screen): pantalla dedicada de Tienda con grid y suscripciones

### DIFF
--- a/App.js
+++ b/App.js
@@ -17,6 +17,7 @@ import PlantScreen from "./src/screens/PlantScreen";
 import ProfileScreen from "./src/screens/ProfileScreen";
 import InventoryScreen from "./src/screens/InventoryScreen";
 import NewsInboxScreen from "./src/screens/NewsInboxScreen";
+import ShopScreen from "./src/screens/ShopScreen";
 import { AppProvider } from "./src/state/AppContext";
 
 const Tab = createBottomTabNavigator();
@@ -54,6 +55,11 @@ export default function App() {
             name="NewsInboxModal"
             component={NewsInboxScreen}
             options={{ presentation: "modal", headerShown: false }}
+          />
+          <RootStack.Screen
+            name="ShopScreen"
+            component={ShopScreen}
+            options={{ headerShown: false }}
           />
         </RootStack.Navigator>
       </NavigationContainer>

--- a/src/components/home/MagicShopSection.js
+++ b/src/components/home/MagicShopSection.js
@@ -7,9 +7,11 @@
 import React, { useState } from "react";
 import { View, Text, Pressable, Alert } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+import { useNavigation } from "@react-navigation/native";
 import styles from "./MagicShopSection.styles";
 import ShopItemCard from "./ShopItemCard";
-import { ShopColors, Colors } from "../../theme";
+import { Colors } from "../../theme";
+import { ShopColors } from "../../constants/shopCatalog";
 import {
   useAppState,
   useAppDispatch,
@@ -77,6 +79,7 @@ const SHOP_ITEMS = {
 };
 
 export default function MagicShopSection({ onLayout }) {
+  const navigation = useNavigation();
   const [activeTab, setActiveTab] = useState("potions");
   const { mana } = useAppState();
   const dispatch = useAppDispatch();
@@ -220,7 +223,9 @@ export default function MagicShopSection({ onLayout }) {
       })}
 
       <Pressable
-        onPress={() => {}}
+        onPress={() =>
+          navigation.navigate("ShopScreen", { initialTab: "potions" })
+        }
         style={styles.viewAllButton}
         accessibilityRole="button"
         accessibilityLabel="Ver todos los artículos"

--- a/src/components/shop/ShopGridItem.js
+++ b/src/components/shop/ShopGridItem.js
@@ -1,0 +1,63 @@
+// [MB] Módulo: Shop / Componente: ShopGridItem
+// Afecta: ShopScreen
+// Propósito: Card de producto en grid 2×N para la tienda
+// Puntos de edición futura: integrar imágenes reales y estados
+// Autor: Codex - Fecha: 2025-08-24
+
+import React, { useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import styles from "./ShopGridItem.styles";
+import { Opacity } from "../../theme";
+
+function currencySymbol(currency) {
+  switch (currency) {
+    case "mana":
+      return "✨";
+    case "coin":
+      return "🪙";
+    default:
+      return "💎";
+  }
+}
+
+function ShopGridItem({
+  sku,
+  emoji,
+  title,
+  desc,
+  price,
+  currency,
+  accent,
+  disabled,
+  onPress,
+  accessibilityLabel,
+}) {
+  const [pressed, setPressed] = useState(false);
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
+      style={[
+        styles.card,
+        { borderColor: accent.border, transform: [{ scale: pressed ? 0.98 : 1 }] },
+        disabled && { opacity: Opacity.disabled },
+      ]}
+      accessibilityRole="button"
+      accessibilityState={{ disabled }}
+      accessibilityLabel={accessibilityLabel}
+    >
+      <Text style={styles.emoji}>{emoji}</Text>
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.desc}>{desc}</Text>
+      <View style={[styles.pricePill, { backgroundColor: accent.pill }]}>
+        <Text style={styles.priceText}>
+          {currencySymbol(currency)}{price}
+        </Text>
+      </View>
+    </Pressable>
+  );
+}
+
+export default React.memo(ShopGridItem);

--- a/src/components/shop/ShopGridItem.styles.js
+++ b/src/components/shop/ShopGridItem.styles.js
@@ -1,0 +1,43 @@
+// [MB] Módulo: Shop / Estilos: ShopGridItem
+// Afecta: ShopScreen
+// Propósito: Estilos para card de producto en grid
+// Puntos de edición futura: ajustar sombras y responsive
+// Autor: Codex - Fecha: 2025-08-24
+
+import { StyleSheet } from "react-native";
+import { Colors, Spacing, Radii, Typography, Elevation } from "../../theme";
+
+export default StyleSheet.create({
+  card: {
+    flex: 1,
+    backgroundColor: Colors.surfaceElevated,
+    borderWidth: 1,
+    borderRadius: Radii.lg,
+    padding: Spacing.base,
+    ...Elevation.card,
+  },
+  emoji: {
+    fontSize: 48,
+    marginBottom: Spacing.small,
+  },
+  title: {
+    ...Typography.title,
+    color: Colors.text,
+  },
+  desc: {
+    ...Typography.caption,
+    color: Colors.textMuted,
+    marginTop: Spacing.tiny,
+    marginBottom: Spacing.small,
+  },
+  pricePill: {
+    alignSelf: "flex-end",
+    borderRadius: Radii.pill,
+    paddingHorizontal: Spacing.small,
+    paddingVertical: Spacing.tiny,
+  },
+  priceText: {
+    ...Typography.body,
+    color: Colors.textInverse,
+  },
+});

--- a/src/components/shop/SubscriptionCard.js
+++ b/src/components/shop/SubscriptionCard.js
@@ -1,0 +1,38 @@
+// [MB] Módulo: Shop / Componente: SubscriptionCard
+// Afecta: ShopScreen
+// Propósito: Mostrar opciones de suscripción con CTA
+// Puntos de edición futura: integrar pasarela de pago real
+// Autor: Codex - Fecha: 2025-08-24
+
+import React from "react";
+import { Pressable, Text, View } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import styles from "./SubscriptionCard.styles";
+import { ShopColors } from "../../constants/shopCatalog";
+
+export default function SubscriptionCard({ tier, priceLabel, badge, desc, onPress }) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={styles.wrapper}
+      accessibilityRole="button"
+      accessibilityLabel={`Suscribirse ${tier}`}
+    >
+      <LinearGradient colors={[ShopColors.subs.bg, "#000"]} style={styles.card}>
+        <View style={styles.header}>
+          <Text style={styles.title}>{tier}</Text>
+          {badge && (
+            <View style={styles.badge}>
+              <Text style={styles.badgeText}>{badge}</Text>
+            </View>
+          )}
+        </View>
+        <Text style={styles.price}>{priceLabel}</Text>
+        <Text style={styles.desc}>{desc}</Text>
+        <View style={styles.cta}>
+          <Text style={styles.ctaText}>Suscribirse</Text>
+        </View>
+      </LinearGradient>
+    </Pressable>
+  );
+}

--- a/src/components/shop/SubscriptionCard.styles.js
+++ b/src/components/shop/SubscriptionCard.styles.js
@@ -1,0 +1,67 @@
+// [MB] Módulo: Shop / Estilos: SubscriptionCard
+// Afecta: ShopScreen
+// Propósito: Estilos para tarjetas de suscripción
+// Puntos de edición futura: agregar variantes y animaciones
+// Autor: Codex - Fecha: 2025-08-24
+
+import { StyleSheet } from "react-native";
+import { Colors, Spacing, Radii, Typography, Elevation } from "../../theme";
+import { ShopColors } from "../../constants/shopCatalog";
+
+export default StyleSheet.create({
+  wrapper: {
+    flex: 1,
+    marginBottom: Spacing.base,
+    width: "100%",
+  },
+  card: {
+    borderRadius: Radii.lg,
+    padding: Spacing.base,
+    borderWidth: 1,
+    borderColor: ShopColors.subs.border,
+    ...Elevation.card,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  title: {
+    ...Typography.title,
+    color: Colors.text,
+    textTransform: "capitalize",
+  },
+  badge: {
+    backgroundColor: ShopColors.subs.pill,
+    borderRadius: Radii.pill,
+    paddingHorizontal: Spacing.small,
+    paddingVertical: Spacing.tiny,
+  },
+  badgeText: {
+    ...Typography.caption,
+    color: Colors.textInverse,
+  },
+  price: {
+    ...Typography.h2,
+    color: Colors.text,
+    marginTop: Spacing.small,
+  },
+  desc: {
+    ...Typography.body,
+    color: Colors.textMuted,
+    marginTop: Spacing.small,
+    marginBottom: Spacing.base,
+  },
+  cta: {
+    backgroundColor: ShopColors.subs.pill,
+    borderRadius: Radii.pill,
+    paddingVertical: Spacing.small,
+    alignItems: "center",
+    ...Elevation.raised,
+  },
+  ctaText: {
+    ...Typography.body,
+    color: Colors.textInverse,
+    fontWeight: "700",
+  },
+});

--- a/src/constants/shopCatalog.js
+++ b/src/constants/shopCatalog.js
@@ -1,11 +1,34 @@
 // [MB] Módulo: Estado / Sección: Catálogo de Tienda
 // Afecta: inventario y recompensas
-// Propósito: Resolver metadatos de ítems por SKU
-// Puntos de edición futura: ampliar catálogo y categorías
-// Autor: Codex - Fecha: 2025-08-13
+// Propósito: Definir catálogo por categoría y acentos
+// Puntos de edición futura: ampliar catálogo, agregar suscripciones
+// Autor: Codex - Fecha: 2025-08-24
+
+export const CURRENCIES = { MANA: "mana", COIN: "coin", GEM: "gem" };
 
 export const SHOP_CATALOG = {
-  "shop/potions/p1": { title: "Poción de Sabiduría", category: "potions" },
-  "shop/potions/p2": { title: "Cristal de Maná", category: "potions" },
+  potions: [
+    { sku: "shop/potions/p1", emoji: "🧪", title: "Poción de Sabiduría", desc: "XP×2 por 2h", price: 50, currency: CURRENCIES.MANA },
+    { sku: "shop/potions/p2", emoji: "💠", title: "Cristal de Maná", desc: "+100 maná", price: 30, currency: CURRENCIES.MANA },
+  ],
+  tools: [
+    { sku: "shop/tools/t1", emoji: "✨", title: "Varita Élfica", desc: "Baja dificultad 1 día", price: 120, currency: CURRENCIES.COIN },
+    { sku: "shop/tools/t2", emoji: "🛡️", title: "Escudo Temporal", desc: "Protege racha 1 día", price: 80, currency: CURRENCIES.COIN },
+  ],
+  cosmetics: [
+    { sku: "shop/cosmetics/c1", emoji: "🏺", title: "Maceta Dorada", desc: "Solo visual", price: 3, currency: CURRENCIES.GEM },
+  ],
 };
 
+export const ShopColors = {
+  potions:   { bg: "#1b1231", border: "#7e57c2", pill: "#B542F6" },
+  tools:     { bg: "#10251c", border: "#1cd47b", pill: "#1cd47b" },
+  cosmetics: { bg: "#2a1022", border: "#F8329D", pill: "#F8329D" },
+  subs:      { bg: "#281e00", border: "#FFD700", pill: "#FFD700" },
+};
+
+export const SHOP_LOOKUP = Object.fromEntries(
+  Object.entries(SHOP_CATALOG).flatMap(([category, items]) =>
+    items.map((item) => [item.sku, { title: item.title, category }])
+  )
+);

--- a/src/screens/ShopScreen.js
+++ b/src/screens/ShopScreen.js
@@ -1,0 +1,266 @@
+// [MB] Módulo: Shop / Pantalla: ShopScreen
+// Afecta: Tienda completa
+// Propósito: Pantalla dedicada de tienda con grid y suscripciones
+// Puntos de edición futura: conectar IAP y expandir catálogo
+// Autor: Codex - Fecha: 2025-08-24
+
+import React, { useState, useCallback, useMemo } from "react";
+import { View, Text, FlatList, Pressable, Alert } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useRoute } from "@react-navigation/native";
+import { Ionicons } from "@expo/vector-icons";
+import styles from "./ShopScreen.styles";
+import ShopGridItem from "../components/shop/ShopGridItem";
+import SubscriptionCard from "../components/shop/SubscriptionCard";
+import {
+  SHOP_CATALOG,
+  ShopColors,
+  CURRENCIES,
+} from "../constants/shopCatalog";
+import { Spacing, Colors } from "../theme";
+import {
+  useAppState,
+  useAppDispatch,
+  useCanAfford,
+  useWallet,
+  useHydrationStatus,
+} from "../state/AppContext";
+import SectionPlaceholder from "../components/home/SectionPlaceholder";
+
+const TABS = [
+  { key: "potions", label: "Pociones" },
+  { key: "tools", label: "Herramientas" },
+  { key: "cosmetics", label: "Cosméticos" },
+  { key: "subs", label: "Suscripciones" },
+];
+
+const SUBSCRIPTION_PLANS = [
+  {
+    id: "sub_monthly",
+    tier: "mensual",
+    priceLabel: "$2.99/mes",
+    desc: "Acceso premium mensual",
+  },
+  {
+    id: "sub_yearly",
+    tier: "anual",
+    priceLabel: "$24.99/año",
+    badge: "Ahorra 30%",
+    desc: "Acceso premium anual",
+  },
+  {
+    id: "sub_lifetime",
+    tier: "de por vida",
+    priceLabel: "$49.99 una sola vez",
+    desc: "Acceso premium permanente",
+  },
+];
+
+export default function ShopScreen() {
+  const route = useRoute();
+  const initialTab = route.params?.initialTab || "potions";
+  const [activeTab, setActiveTab] = useState(initialTab);
+  const { mana } = useAppState();
+  const wallet = useWallet();
+  const dispatch = useAppDispatch();
+  const canAffordMana = useCanAfford();
+  const hydration = useHydrationStatus();
+
+  const canAffordCurrency = useCallback(
+    (currency, amount) => wallet[currency] >= amount,
+    [wallet]
+  );
+
+  const columnStyle = useMemo(() => ({ gap: Spacing.base }), []);
+  const contentStyle = useMemo(
+    () => ({ padding: Spacing.base, paddingBottom: 120 }),
+    []
+  );
+
+  const handleBuy = useCallback(
+    (item) => {
+      if (item.currency === CURRENCIES.MANA) {
+        if (canAffordMana(item.price)) {
+          dispatch({ type: "PURCHASE_WITH_MANA", payload: item.price });
+        } else {
+          Alert.alert("Sin maná", "Maná insuficiente");
+          return;
+        }
+      } else if (item.currency === CURRENCIES.COIN) {
+        if (canAffordCurrency("coin", item.price)) {
+          dispatch({ type: "SPEND_COIN", payload: item.price });
+        } else {
+          Alert.alert("Sin monedas", "Monedas insuficientes");
+          return;
+        }
+      } else if (item.currency === CURRENCIES.GEM) {
+        Alert.alert(
+          "Próximamente",
+          "Las compras con diamantes requieren IAP"
+        );
+        return;
+      }
+
+      dispatch({
+        type: "ADD_TO_INVENTORY",
+        payload: { sku: item.sku, title: item.title, category: activeTab },
+      });
+      dispatch({
+        type: "ACHIEVEMENT_EVENT",
+        payload: { type: "purchase", payload: { sku: item.sku, category: activeTab } },
+      });
+      Alert.alert("Compra exitosa — añadido al inventario");
+    },
+    [activeTab, canAffordCurrency, canAffordMana, dispatch]
+  );
+
+  const renderItem = useCallback(
+    ({ item }) => {
+      if (activeTab === "subs") {
+        return (
+          <SubscriptionCard
+            tier={item.tier}
+            priceLabel={item.priceLabel}
+            badge={item.badge}
+            desc={item.desc}
+            onPress={() =>
+              Alert.alert(
+                "Próximamente",
+                "Las suscripciones requerirán pasarela de pago/IAP"
+              )
+            }
+          />
+        );
+      }
+      const disabled =
+        item.currency === CURRENCIES.MANA
+          ? !canAffordMana(item.price)
+          : item.currency === CURRENCIES.COIN
+          ? !canAffordCurrency("coin", item.price)
+          : false;
+      const label = `Comprar ${item.title} por ${item.price} ${
+        item.currency === CURRENCIES.MANA
+          ? "maná"
+          : item.currency === CURRENCIES.COIN
+          ? "monedas"
+          : "diamantes"
+      }`;
+      return (
+        <ShopGridItem
+          {...item}
+          accent={ShopColors[activeTab]}
+          disabled={disabled}
+          onPress={() => handleBuy(item)}
+          accessibilityLabel={label}
+        />
+      );
+    },
+    [activeTab, canAffordCurrency, canAffordMana, handleBuy]
+  );
+
+  const data = activeTab === "subs" ? SUBSCRIPTION_PLANS : SHOP_CATALOG[activeTab];
+
+  if (hydration.mana || hydration.wallet) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <SectionPlaceholder height={300} />
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View
+        style={styles.header}
+        accessible
+        accessibilityLabel={`Saldo: ${mana} maná, ${wallet.coin} monedas, ${wallet.gem} diamantes`}
+      >
+        <Text style={styles.headerTitle}>Tienda Mágica</Text>
+        <View style={styles.walletRow}>
+          <View
+            style={[styles.manaPill, { borderColor: ShopColors[activeTab].pill }]}
+          >
+            <Ionicons
+              name="sparkles"
+              size={16}
+              color={ShopColors[activeTab].pill}
+              style={styles.manaIcon}
+            />
+            <Text style={styles.manaValue}>{mana}</Text>
+          </View>
+          <View style={styles.currencyPill}>
+            <Ionicons
+              name="logo-bitcoin"
+              size={14}
+              color={Colors.text}
+              style={styles.currencyIcon}
+            />
+            <Text style={styles.currencyValue}>{wallet.coin}</Text>
+          </View>
+          <View style={styles.currencyPill}>
+            <Ionicons
+              name="diamond"
+              size={14}
+              color={Colors.text}
+              style={styles.currencyIcon}
+            />
+            <Text style={styles.currencyValue}>{wallet.gem}</Text>
+          </View>
+        </View>
+      </View>
+      <View style={styles.tabsRow}>
+        {TABS.map((tab) => {
+          const isActive = tab.key === activeTab;
+          const accent = ShopColors[tab.key];
+          return (
+            <Pressable
+              key={tab.key}
+              onPress={() => setActiveTab(tab.key)}
+              style={[
+                styles.tabButton,
+                isActive && {
+                  backgroundColor: accent.bg,
+                  borderColor: accent.border,
+                },
+              ]}
+              accessibilityRole="tab"
+              accessibilityState={{ selected: isActive }}
+              accessibilityLabel={`Mostrar ${tab.label}`}
+            >
+              <Text style={styles.tabText}>{tab.label}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+      <FlatList
+        data={data}
+        keyExtractor={(item) => item.sku || item.id}
+        renderItem={renderItem}
+        numColumns={activeTab === "subs" ? 1 : 2}
+        columnWrapperStyle={activeTab === "subs" ? undefined : columnStyle}
+        contentContainerStyle={contentStyle}
+        initialNumToRender={6}
+        removeClippedSubviews
+        windowSize={5}
+        ListEmptyComponent={
+          <Text style={styles.emptyText}>Sin artículos</Text>
+        }
+        ListFooterComponent={
+          <View style={styles.footer}>
+            <Text style={styles.footerText}>
+              Las compras son finales. ¿Necesitas ayuda?
+            </Text>
+            <Pressable
+              onPress={() => Alert.alert("Soporte", "Próximamente")}
+              style={styles.supportButton}
+              accessibilityRole="button"
+            >
+              <Text style={styles.supportButtonText}>Soporte</Text>
+            </Pressable>
+          </View>
+        }
+        accessibilityRole="list"
+      />
+    </SafeAreaView>
+  );
+}

--- a/src/screens/ShopScreen.styles.js
+++ b/src/screens/ShopScreen.styles.js
@@ -1,0 +1,109 @@
+// [MB] Módulo: Shop / Estilos: ShopScreen
+// Afecta: Tienda completa
+// Propósito: Estilos para pantalla dedicada de la tienda
+// Puntos de edición futura: optimizar disposición y theming
+// Autor: Codex - Fecha: 2025-08-24
+
+import { StyleSheet } from "react-native";
+import { Colors, Spacing, Radii, Typography } from "../theme";
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.background,
+  },
+  header: {
+    padding: Spacing.base,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+    backgroundColor: Colors.surface,
+  },
+  headerTitle: {
+    ...Typography.h2,
+    color: Colors.text,
+    marginBottom: Spacing.small,
+  },
+  walletRow: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  manaPill: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderWidth: 1,
+    borderRadius: Radii.pill,
+    paddingHorizontal: Spacing.base,
+    height: 28,
+  },
+  manaIcon: {
+    marginRight: Spacing.small,
+  },
+  manaValue: {
+    ...Typography.body,
+    color: Colors.text,
+  },
+  currencyPill: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: Radii.pill,
+    paddingHorizontal: Spacing.small,
+    height: 24,
+    marginLeft: Spacing.small,
+  },
+  currencyIcon: {
+    marginRight: Spacing.tiny,
+  },
+  currencyValue: {
+    ...Typography.caption,
+    color: Colors.text,
+  },
+  tabsRow: {
+    flexDirection: "row",
+    paddingHorizontal: Spacing.base,
+    paddingTop: Spacing.base,
+  },
+  tabButton: {
+    flex: 1,
+    height: 40,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: Radii.lg,
+    justifyContent: "center",
+    alignItems: "center",
+    marginRight: Spacing.small,
+  },
+  tabText: {
+    ...Typography.body,
+    color: Colors.text,
+    fontSize: 12,
+  },
+  emptyText: {
+    ...Typography.body,
+    color: Colors.textMuted,
+    textAlign: "center",
+    marginTop: Spacing.base,
+  },
+  footer: {
+    padding: Spacing.base,
+    alignItems: "center",
+  },
+  footerText: {
+    ...Typography.caption,
+    color: Colors.textMuted,
+    textAlign: "center",
+    marginBottom: Spacing.small,
+  },
+  supportButton: {
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: Radii.md,
+    paddingVertical: Spacing.small,
+    paddingHorizontal: Spacing.base,
+  },
+  supportButtonText: {
+    ...Typography.body,
+    color: Colors.text,
+  },
+});

--- a/src/state/AppContext.js
+++ b/src/state/AppContext.js
@@ -38,7 +38,7 @@ import {
   setAchievementsState,
 } from "../storage";
 import { DAILY_REWARDS } from "../constants/dailyRewards";
-import { SHOP_CATALOG } from "../constants/shopCatalog";
+import { SHOP_LOOKUP } from "../constants/shopCatalog";
 import { CHALLENGE_TEMPLATES } from "../constants/challengeTemplates";
 import {
   hashStringToInt,
@@ -339,7 +339,7 @@ function appReducer(state, action) {
         });
       } else if (reward.kind === "item" && reward.sku) {
         const info =
-          SHOP_CATALOG[reward.sku] || {
+          SHOP_LOOKUP[reward.sku] || {
             title: "Ítem misterioso",
             category: "potions",
           };

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,8 +1,8 @@
 // src/theme.js
 /* [MB] Módulo: Sistema de diseño / Sección: Tokens globales
-   Afecta: toda la app (colores, espaciado, tipografía, radios, elevación, acentos tienda)
+   Afecta: toda la app (colores, espaciado, tipografía, radios, elevación)
    Propósito: unificar estilos y facilitar que Codex y yo creemos UI coherente
-   Puntos de edición futura: ShopColors, Typography, Radii
+   Puntos de edición futura: Typography, Radii
 */
 
 export const Colors = {
@@ -100,12 +100,6 @@ export const Gradients = {
   xp: [Colors.primary, Colors.primaryLight],
 };
 
-// Acentos por pestaña de la Tienda (ajústalos a tu gusto)
-export const ShopColors = {
-  potions: { bg: "#2F1B4C", border: "#8060D0", pill: "#7442FF" },
-  tools: { bg: "#0F2A46", border: "#2D6DB2", pill: "#1E90FF" },
-  cosmetics: { bg: "#3A2A0F", border: "#C7A039", pill: "#E2C36A" },
-};
 
 export const Opacity = {
   disabled: 0.5,


### PR DESCRIPTION
## Summary
- add ShopScreen with wallet header, tabbed grid and subscription placeholders
- create ShopGridItem and SubscriptionCard components with emoji pricing
- wire navigation from home and centralize shop catalog & colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bfb97a5588327a983d399ee936ad7