### PR TITLE
feat: switch cosmetics to gold palette

### DIFF
--- a/src/constants/shopCatalog.js
+++ b/src/constants/shopCatalog.js
@@ -2,7 +2,7 @@
 // Afecta: inventario y recompensas
 // Propósito: Definir catálogo por categoría y acentos
 // Puntos de edición futura: ampliar catálogo, agregar suscripciones
-// Autor: Codex - Fecha: 2025-08-24
+// Autor: Codex - Fecha: 2025-08-13
 
 export const CURRENCIES = { MANA: "mana", COIN: "coin", GEM: "gem" };
 
@@ -23,7 +23,7 @@ export const SHOP_CATALOG = {
 export const ShopColors = {
   potions:   { bg: "#1b1231", border: "#7e57c2", pill: "#B542F6" },
   tools:     { bg: "#10251c", border: "#1cd47b", pill: "#1cd47b" },
-  cosmetics: { bg: "#2a1022", border: "#F8329D", pill: "#F8329D" },
+  cosmetics: { bg: "#281e00", border: "#FFD700", pill: "#FFD700" },
   subs:      { bg: "#281e00", border: "#FFD700", pill: "#FFD700" },
 };
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -3,6 +3,7 @@
    Afecta: toda la app (colores, espaciado, tipografía, radios, elevación)
    Propósito: unificar estilos y facilitar que Codex y yo creemos UI coherente
    Puntos de edición futura: Typography, Radii
+   Autor: Codex - Fecha: 2025-08-13
 */
 
 export const Colors = {
@@ -25,8 +26,7 @@ export const Colors = {
 
   // Fantasía (gradientes/decor)
   primaryFantasy: "#B542F6",
-  secondaryFantasy: "#F8329D",
-  tertiaryFantasy: "#FFD700",
+  secondaryFantasy: "#FFD700",
 
   // Estados
   success: "#1db954",


### PR DESCRIPTION
## Summary
- use gold accents for cosmetics in shop catalog
- drop obsolete magenta token from theme and switch gradient to gold

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c04afbea483278ed0d528539c8c3c