### PR TITLE
style: improve ShopGridItem layout

### DIFF
--- a/src/components/shop/ShopGridItem.styles.js
+++ b/src/components/shop/ShopGridItem.styles.js
@@ -10,6 +10,8 @@ import { Colors, Spacing, Radii, Typography, Elevation } from "../../theme";
 export default StyleSheet.create({
   card: {
     flex: 1,
+    justifyContent: "space-between",
+    minHeight: Spacing.xlarge * 5,
     backgroundColor: Colors.surfaceElevated,
     borderWidth: 1,
     borderRadius: Radii.lg,
@@ -32,6 +34,8 @@ export default StyleSheet.create({
   },
   pricePill: {
     alignSelf: "flex-end",
+    minWidth: Spacing.xlarge * 2,
+    alignItems: "center",
     borderRadius: Radii.pill,
     paddingHorizontal: Spacing.small,
     paddingVertical: Spacing.tiny,


### PR DESCRIPTION
## Summary
- keep ShopGridItem card layout consistent with minimum height and spaced content
- ensure price chip remains centered with minimum width

## Testing
- `npm run build` *(fails: Missing script: "build")*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c058ad6ac8327ac3c638238779aab