### PR TITLE
Add close button to Shop screen header

### DIFF
--- a/src/screens/ShopScreen.js
+++ b/src/screens/ShopScreen.js
@@ -7,7 +7,7 @@
 import React, { useState, useCallback, useMemo } from "react";
 import { View, Text, FlatList, Pressable, Alert } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useRoute } from "@react-navigation/native";
+import { useRoute, useNavigation } from "@react-navigation/native";
 import { Ionicons } from "@expo/vector-icons";
 import styles from "./ShopScreen.styles";
 import ShopGridItem from "../components/shop/ShopGridItem";
@@ -58,6 +58,7 @@ const SUBSCRIPTION_PLANS = [
 
 export default function ShopScreen() {
   const route = useRoute();
+  const navigation = useNavigation();
   const initialTab = route.params?.initialTab || "potions";
   const [activeTab, setActiveTab] = useState(initialTab);
   const { mana } = useAppState();
@@ -175,6 +176,14 @@ export default function ShopScreen() {
         accessible
         accessibilityLabel={`Saldo: ${mana} maná, ${wallet.coin} monedas, ${wallet.gem} diamantes`}
       >
+        <Pressable
+          onPress={() => navigation.goBack()}
+          style={styles.closeButton}
+          accessibilityLabel="Cerrar tienda"
+          accessibilityRole="button"
+        >
+          <Ionicons name="close" size={20} color={Colors.text} />
+        </Pressable>
         <Text style={styles.headerTitle}>Tienda Mágica</Text>
         <View style={styles.walletRow}>
           <View

--- a/src/screens/ShopScreen.styles.js
+++ b/src/screens/ShopScreen.styles.js
@@ -18,6 +18,13 @@ export default StyleSheet.create({
     borderBottomColor: Colors.border,
     backgroundColor: Colors.surface,
   },
+  closeButton: {
+    position: "absolute",
+    top: Spacing.base,
+    right: Spacing.base,
+    padding: Spacing.small,
+    borderRadius: Radii.md,
+  },
   headerTitle: {
     ...Typography.h2,
     color: Colors.text,


### PR DESCRIPTION
## Summary
- add accessible close button to shop header that navigates back
- style new header button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c059c13cc8327ae8d3113cf1913c8