### PR TITLE
fix: guard setAnchor layout access

### DIFF
--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -27,7 +27,12 @@ export default function HomeScreen() {
   const [anchors, setAnchors] = useState({});
 
   const setAnchor = useCallback(
-    (key) => (e) => setAnchors((a) => ({ ...a, [key]: e.nativeEvent.layout.y })),
+    (key) => (e) => {
+      const y = e?.nativeEvent?.layout?.y;
+      if (typeof y === "number") {
+        setAnchors((a) => ({ ...a, [key]: y }));
+      }
+    },
     []
   );
   const scrollToShop = useCallback(() => {


### PR DESCRIPTION
## Summary
- guard HomeScreen setAnchor callback against missing nativeEvent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c0e479acc8327ba26e34ede791d2e