### PR TITLE
fix: remove invalid listitem accessibility roles

### DIFF
--- a/src/components/home/DailyChallengesSection.js
+++ b/src/components/home/DailyChallengesSection.js
@@ -50,7 +50,7 @@ function DailyChallengesSection() {
             ? "Reclamado"
             : "En progreso";
           return (
-            <View key={item.id} style={styles.card} accessibilityRole="listitem">
+            <View key={item.id} style={styles.card}>
               <View style={styles.headerRow}>
                 <Text style={styles.challengeTitle}>{item.title}</Text>
                 <View style={styles.rewardPill}>

--- a/src/components/home/InventorySection.js
+++ b/src/components/home/InventorySection.js
@@ -91,7 +91,7 @@ function InventorySection({ onGoToShop }) {
 
       <View style={styles.list} accessibilityRole="list">
         {preview.map((item) => (
-          <View key={item.id} style={styles.itemRow} accessibilityRole="listitem">
+          <View key={item.id} style={styles.itemRow}>
             <Text style={styles.itemIcon}>
               {CATEGORY_EMOJI[item.category] || "📦"}
             </Text>

--- a/src/components/home/MagicShopSection.js
+++ b/src/components/home/MagicShopSection.js
@@ -217,7 +217,7 @@ function MagicShopSection() {
         {SHOP_ITEMS[activeTab].map((item) => {
           const affordable = canAfford(item.price);
           return (
-            <View key={item.id} style={styles.itemWrapper} accessibilityRole="listitem">
+            <View key={item.id} style={styles.itemWrapper}>
               <ShopItemCard
                 title={item.title}
                 description={item.description}

--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -355,6 +355,7 @@ export default function TasksScreen() {
         )}
         style={styles.list}
         contentContainerStyle={{ paddingBottom: 96 }}
+        accessibilityRole="list"
       />
 
       <AddTaskButton onPress={onAddTask} />


### PR DESCRIPTION
## Summary
- remove unsupported `listitem` role from inventory preview, challenges, and shop sections
- mark task list `FlatList` container as a11y `list`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c12866ec883278ef839f81307911f