### PR TITLE
fix: adjust tag scroll containers in CreateTaskModal

### DIFF
--- a/src/components/CreateTaskModal/CreateTaskModal.js
+++ b/src/components/CreateTaskModal/CreateTaskModal.js
@@ -507,8 +507,7 @@ export default function CreateTaskModal({
               <ScrollView
                 horizontal
                 showsHorizontalScrollIndicator={false}
-                style={styles.row}
-                contentContainerStyle={{ alignItems: "center" }}
+                contentContainerStyle={styles.chipScrollContent}
               >
                 {uniqueTags.map((tagKey) => {
                   const active = newTags.includes(tagKey);
@@ -557,8 +556,7 @@ export default function CreateTaskModal({
                 <ScrollView
                   horizontal
                   showsHorizontalScrollIndicator={false}
-                  style={styles.row}
-                  contentContainerStyle={{ alignItems: "center" }}
+                  contentContainerStyle={styles.chipScrollContent}
                 >
                   {newTags.map((tag) => (
                     <View key={tag} style={styles.chip}>

--- a/src/components/CreateTaskModal/CreateTaskModal.styles.js
+++ b/src/components/CreateTaskModal/CreateTaskModal.styles.js
@@ -1,6 +1,8 @@
-// [MB] CreateTaskModal.styles.js — estilos del modal de tareas alineados al tema (solo estilos, sin tocar la estructura)
-// Módulo: Tasks > CreateTaskModal
-// Propósito: Unificar visual con Home (fondos, radios, tipografías, paddings, chips y botones) usando tokens.
+// [MB] Módulo: Tasks / Sección: CreateTaskModal
+// Afecta: CreateTaskModal
+// Propósito: Estilos del modal para crear y editar tareas
+// Puntos de edición futura: tokens en theme y ajustes de spacing
+// Autor: Codex - Fecha: 2025-08-13
 
 import { StyleSheet } from "react-native";
 import { Colors, Spacing, Radii, Elevation /*, Typography*/ } from "../../theme";
@@ -149,6 +151,12 @@ export default StyleSheet.create({
   chipLabelActive: {
     color: Colors.text,
     fontWeight: "700",
+  },
+
+  chipScrollContent: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.small,
   },
 
   // Subtareas: fila input + botón "+"


### PR DESCRIPTION
## Summary
- fix horizontal ScrollView warnings by moving row styling to `contentContainerStyle`
- add `chipScrollContent` style for chip lists without `justifyContent: 'space-between'`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c231a85708327970d99f4ab3e5de1