### PR TITLE
fix(tasks/modal): grid 2x2 de Elemento y margen superior del título

### DIFF
--- a/src/components/CreateTaskModal/CreateTaskModal.js
+++ b/src/components/CreateTaskModal/CreateTaskModal.js
@@ -85,6 +85,7 @@ export default function CreateTaskModal({
   const [newSubtaskInput, setNewSubtaskInput] = useState("");
   const [newSubtasks, setNewSubtasks] = useState([]); // [{id,text,completed}]
   const [alert, setAlert] = useState(null); // { message, type }
+  const [gridWidth, setGridWidth] = useState(0);
 
   useEffect(() => {
     if (task) {
@@ -279,19 +280,32 @@ export default function CreateTaskModal({
             </View>
 
             <Text style={styles.sectionLabel}>Elemento</Text>
-            <View style={styles.elementGrid}>
+            <View
+              style={styles.elementGrid}
+              onLayout={(e) => setGridWidth(e.nativeEvent.layout.width)}
+            >
               {ELEMENTS.map((name, idx) => {
                 const accent = ELEMENT_ACCENTS[name];
                 const selected = newElement === accent.value;
+                const cardSize = gridWidth
+                  ? (gridWidth - Spacing.base) / 2
+                  : 0;
                 return (
                   <Pressable
                     key={name}
                     onPress={() => setNewElement(accent.value)}
                     style={[
                       styles.elementCard,
-                      { borderColor: accent.border },
-                      selected && styles.elementCardActive,
-                      idx % 2 === 0 && styles.elementCardLeft,
+                      {
+                        borderColor: accent.border,
+                        width: cardSize,
+                        height: cardSize,
+                        marginRight: idx % 2 === 0 ? Spacing.base : 0,
+                      },
+                      selected && [
+                        styles.elementCardActive,
+                        { shadowColor: accent.border },
+                      ],
                     ]}
                     accessibilityRole="button"
                     accessibilityState={{ selected }}

--- a/src/components/CreateTaskModal/CreateTaskModal.styles.js
+++ b/src/components/CreateTaskModal/CreateTaskModal.styles.js
@@ -18,6 +18,7 @@ export default StyleSheet.create({
   title: {
     ...(Typography?.h2 || { fontSize: 22, fontWeight: "700" }),
     color: Colors.text,
+    marginTop: Spacing.large,
     marginBottom: Spacing.small,
   },
 
@@ -99,37 +100,31 @@ export default StyleSheet.create({
   elementGrid: {
     flexDirection: "row",
     flexWrap: "wrap",
-    justifyContent: "space-between",
     marginTop: Spacing.small,
   },
   elementCard: {
     position: "relative",
-    flexBasis: "48%",
-    maxWidth: "48%",
     borderWidth: 2,
     borderRadius: Radii.lg,
     backgroundColor: Colors.surface,
-    paddingVertical: Spacing.base,
-    paddingHorizontal: Spacing.base,
+    padding: Spacing.base,
     alignItems: "center",
     justifyContent: "center",
     marginBottom: Spacing.base,
+    overflow: "hidden",
     ...(Elevation?.card || {}),
   },
-  elementCardLeft: {
-    marginRight: Spacing.base / 2,
-  },
   elementCardActive: {
-    shadowColor: "#000",
-    shadowOpacity: 0.35,
+    shadowOpacity: 0.45,
     shadowRadius: 12,
     elevation: 6,
-    borderWidth: 2.5,
+    borderWidth: 3,
   },
   elementGradient: {
     ...StyleSheet.absoluteFillObject,
     borderRadius: Radii.lg,
     opacity: 0.35,
+    pointerEvents: "none",
   },
   elementEmoji: { fontSize: 32, marginBottom: Spacing.tiny },
   elementTitle: {


### PR DESCRIPTION
## Summary
- add top spacing to Create Task modal title for better visual separation
- implement true 2x2 Element grid with fixed card size, gradient glow and selectable borders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c2d3e2b688327bdca486359f4be61