### PR TITLE
[MB] Task screen tokenized layout and safe-area fixes

### DIFF
--- a/src/components/AddTaskButton/AddTaskButton.js
+++ b/src/components/AddTaskButton/AddTaskButton.js
@@ -9,7 +9,7 @@ import { TouchableOpacity } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { FontAwesome } from "@expo/vector-icons";
 import styles from "./AddTaskButton.styles";
-import { Colors } from "../../theme";
+import { Colors, Gradients } from "../../theme";
 
 export default function AddTaskButton({ onPress }) {
   const [isPressed, setIsPressed] = useState(false);
@@ -19,11 +19,10 @@ export default function AddTaskButton({ onPress }) {
       onPress={onPress}
       onPressIn={() => setIsPressed(true)}
       onPressOut={() => setIsPressed(false)}
+      accessibilityRole="button"
+      accessibilityLabel="Añadir tarea"
     >
-      <LinearGradient
-        colors={["#6d56d3ff", "#0ca790ff"]} // Nueva paleta de colores para el degradado
-        style={styles.gradient}
-      >
+      <LinearGradient colors={Gradients.mana} style={styles.gradient}>
         <FontAwesome name="plus" size={20} color={Colors.text} />
       </LinearGradient>
     </TouchableOpacity>

--- a/src/components/FilterBar/FilterBar.js
+++ b/src/components/FilterBar/FilterBar.js
@@ -9,7 +9,7 @@ import { View, ScrollView, Pressable, Text } from "react-native";
 import { FontAwesome5, FontAwesome } from "@expo/vector-icons";
 // Los estilos de la barra de filtros residen en FilterBar.styles.js
 import styles from "./FilterBar.styles";
-import { Colors } from "../../theme";
+import { Colors, Spacing } from "../../theme";
 
 export default function FilterBar({ filters, active, onSelect }) {
   return (
@@ -29,23 +29,30 @@ export default function FilterBar({ filters, active, onSelect }) {
             return (
               <Pressable
                 key={f.key}
-                style={[styles.tab, isActive && styles.tabActive]}
+                style={({ pressed }) => [
+                  styles.tab,
+                  isActive && styles.tabActive,
+                  pressed && { opacity: 0.9 },
+                ]}
                 onPress={() => onSelect(f.key)}
-                accessibilityRole="tab"
+                accessibilityRole="button"
+                accessibilityLabel={`Filtrar por ${f.label}`}
                 accessibilityState={{ selected: isActive }}
-                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                hitSlop={{
+                  top: Spacing.small,
+                  bottom: Spacing.small,
+                  left: Spacing.small,
+                  right: Spacing.small,
+                }}
               >
                 <Icon
                   name={f.icon}
                   size={14}
-                  color={isActive ? Colors.text : Colors.textMuted}
+                  color={isActive ? Colors.background : Colors.textMuted}
                   style={styles.icon}
                 />
                 <Text
-                  style={[
-                    styles.tabLabel,
-                    !isActive && styles.tabLabelMuted,
-                  ]}
+                  style={[styles.tabLabel, !isActive && styles.tabLabelInactive]}
                 >
                   {f.label}
                 </Text>

--- a/src/components/FilterBar/FilterBar.styles.js
+++ b/src/components/FilterBar/FilterBar.styles.js
@@ -19,9 +19,9 @@ export default StyleSheet.create({
     backgroundColor: Colors.surface,
     borderRadius: Radii.lg,
     paddingHorizontal: Spacing.base,
-    minHeight: 44,
+    minHeight: 40,
     borderWidth: 1,
-    borderColor: Colors.textMuted + "40",
+    borderColor: Colors.separator,
   },
 
   // Scroll horizontal
@@ -40,28 +40,27 @@ export default StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     paddingHorizontal: Spacing.base,
-    minHeight: 36,
+    height: 36,
     borderRadius: Radii.pill,
     borderWidth: 1,
-    borderColor: Colors.textMuted,
-    backgroundColor: Colors.surface,
+    borderColor: Colors.separator,
+    backgroundColor: Colors.surfaceElevated,
     marginRight: Spacing.small,
   },
   tabActive: {
-    borderColor: Colors.primary,
-    backgroundColor: Colors.surfaceElevated || Colors.surface,
+    backgroundColor: Colors.accent,
+    borderColor: Colors.accent,
   },
   icon: {
-    marginRight: 6,
+    marginRight: Spacing.small,
   },
   tabLabel: {
     fontSize: 14,
     fontWeight: "600",
-    color: Colors.text,
+    color: Colors.background,
     textAlign: "center",
   },
-  tabLabelMuted: {
+  tabLabelInactive: {
     color: Colors.textMuted,
-    fontWeight: "500",
   },
 });

--- a/src/components/SearchBar/SearchBar.styles.js
+++ b/src/components/SearchBar/SearchBar.styles.js
@@ -11,15 +11,15 @@ export default StyleSheet.create({
   container: {
     flexDirection: "row",
     alignItems: "center",
-    backgroundColor: Colors.surface,
+    backgroundColor: Colors.surfaceElevated,
     paddingHorizontal: Spacing.base,
     borderRadius: Radii.lg,
     marginTop: Spacing.small,
     marginBottom: Spacing.small,
     justifyContent: "space-between",
-    minHeight: 44,
+    minHeight: 48,
     borderWidth: 1,
-    borderColor: Colors.textMuted + "40",
+    borderColor: Colors.separator,
   },
   inner: {
     flexDirection: "row",

--- a/src/components/SwipeableTaskItem/SwipeableTaskItem.js
+++ b/src/components/SwipeableTaskItem/SwipeableTaskItem.js
@@ -83,6 +83,7 @@ export default function SwipeableTaskItem({
   if (!task) return null;
 
   const pan = useRef(new Animated.Value(0)).current;
+  const scale = useRef(new Animated.Value(1)).current;
   const threshold = 80;
   const isDeletedView = activeFilter === "deleted";
   const isCompletedView = activeFilter === "completed";
@@ -114,6 +115,12 @@ export default function SwipeableTaskItem({
       },
     })
   ).current;
+  const handlePressIn = () => {
+    Animated.spring(scale, { toValue: 0.98, useNativeDriver: true }).start();
+  };
+  const handlePressOut = () => {
+    Animated.spring(scale, { toValue: 1, useNativeDriver: true }).start();
+  };
   // Información del elemento (icono y color)
   // se usa una función para evitar lógica compleja en el render
   const elementInfo = getElementColor(task.element);
@@ -181,12 +188,14 @@ export default function SwipeableTaskItem({
         style={[
           styles.taskItem,
           {
-            transform: [{ translateX: pan }],
+            transform: [{ translateX: pan }, { scale }],
             opacity: task.completed || task.isDeleted ? 0.5 : 1,
             borderLeftColor: getPriorityColor(task.priority),
           },
         ]}
         {...panResponder.panHandlers}
+        onTouchStart={handlePressIn}
+        onTouchEnd={handlePressOut}
       >
         <TouchableOpacity
           style={styles.contentRow}
@@ -198,7 +207,11 @@ export default function SwipeableTaskItem({
             >
               {task.title}
             </Text>
-            <Text style={[styles.note, task.completed && styles.textCompleted]}>
+            <Text
+              style={[styles.note, task.completed && styles.textCompleted]}
+              numberOfLines={2}
+              ellipsizeMode="tail"
+            >
               {task.note}
             </Text>
           </View>

--- a/src/components/SwipeableTaskItem/SwipeableTaskItem.styles.js
+++ b/src/components/SwipeableTaskItem/SwipeableTaskItem.styles.js
@@ -1,11 +1,21 @@
-// src/components/SwipeableTaskItem/SwipeableTaskItem.styles.js
+// [MB] Módulo: Tasks / Sección: Tarea swipeable
+// Afecta: SwipeableTaskItem
+// Propósito: estilos de tarjeta y chips
+// Puntos de edición futura: animaciones y badges
+// Autor: Codex - Fecha: 2025-08-13
 
 import { StyleSheet } from "react-native";
-import { Colors, Spacing } from "../../theme";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Elevation,
+  Typography,
+} from "../../theme";
 
 export default StyleSheet.create({
   container: {
-    marginBottom: Spacing.small,
+    marginVertical: Spacing.small,
   },
   actionsOverlay: {
     ...StyleSheet.absoluteFillObject,
@@ -40,17 +50,11 @@ export default StyleSheet.create({
     fontSize: 12,
   },
   taskItem: {
-    // tarjeta de tarea
-    backgroundColor: Colors.surface,
-    borderRadius: Spacing.small,
-    padding: Spacing.base,
-    borderLeftWidth: 2,
-    shadowColor: Colors.shadow,
-
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.25,
-    shadowRadius: 3.84,
-    elevation: 5,
+    backgroundColor: Colors.surfaceElevated,
+    borderRadius: Radii.lg,
+    padding: Spacing.small + Spacing.tiny,
+    borderLeftWidth: Spacing.tiny / 2,
+    ...Elevation.card,
   },
   contentRow: {
     flexDirection: "row",
@@ -61,13 +65,12 @@ export default StyleSheet.create({
     marginLeft: 1,
   },
   title: {
+    ...Typography.title,
     color: Colors.text,
-    fontSize: 17,
-    fontWeight: "600",
   },
   note: {
+    ...Typography.body,
     color: Colors.textMuted,
-    fontSize: 14,
     marginTop: Spacing.tiny,
     marginBottom: Spacing.small,
   },
@@ -128,19 +131,16 @@ export default StyleSheet.create({
     marginTop: Spacing.small,
   },
   tagChip: {
-    // chip de etiqueta en tarjeta de tarea
-    backgroundColor: Colors.background,
-    borderRadius: 5,
+    backgroundColor: Colors.surface,
+    borderRadius: Radii.pill,
     paddingHorizontal: Spacing.small,
-    paddingVertical: 3,
+    paddingVertical: Spacing.tiny,
     marginRight: Spacing.tiny,
-    marginTop: 0.1,
+    marginTop: Spacing.tiny,
   },
   tagText: {
+    ...Typography.caption,
     color: Colors.text,
-    fontSize: 11,
-    alignContent: "center",
-    paddingBottom: 1,
   },
 
   // badge de elemento (círculo con icono)
@@ -169,30 +169,30 @@ export default StyleSheet.create({
   badge: {
     flexDirection: "row",
     alignItems: "center",
-    borderRadius: 8,
+    borderRadius: Radii.md,
     paddingHorizontal: Spacing.small,
     paddingVertical: Spacing.tiny,
     marginRight: Spacing.small,
-    marginTop: 1,
+    marginTop: Spacing.tiny,
   },
   badgeIcon: {
     marginRight: Spacing.tiny,
   },
   badgeText: {
-    fontSize: 12,
+    ...Typography.caption,
     fontWeight: "600",
   },
   // chip de prioridad:
   priorityChip: {
-    borderWidth: 0.5,
-    borderRadius: 8,
+    borderRadius: Radii.pill,
     paddingHorizontal: Spacing.small,
-    paddingVertical: 4,
+    paddingVertical: Spacing.tiny,
     justifyContent: "center",
     alignItems: "center",
+    borderWidth: StyleSheet.hairlineWidth,
   },
   priorityChipText: {
-    fontSize: 12,
+    ...Typography.caption,
     fontWeight: "500",
     textTransform: "capitalize",
   },

--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -5,7 +5,14 @@
 // Autor: Codex - Fecha: 2025-08-13
 
 import React, { useState, useEffect } from "react";
-import { SafeAreaView, FlatList, Modal, View } from "react-native";
+import {
+  SafeAreaView,
+  FlatList,
+  Modal,
+  View,
+  StatusBar,
+  Platform,
+} from "react-native";
 import { getTasks as getStoredTasks, setTasks as setStoredTasks } from "../storage";
 
 import StatsHeader from "../components/StatsHeader";
@@ -323,19 +330,21 @@ export default function TasksScreen() {
 
   // ——— 5) Render ———
   return (
-    <SafeAreaView style={styles.container}>
-      <StatsHeader />
-
-      <FilterBar
-        filters={statusFilters}
-        active={statusFilter}
-        onSelect={setStatusFilter}
-      />
-
-      <SearchBar
-        value={searchQuery}
-        onChange={setSearchQuery}
-        onToggleAdvanced={() => setFiltersVisible(true)}
+    <SafeAreaView
+      style={[
+        styles.container,
+        {
+          paddingTop: Platform.select({
+            android: (StatusBar.currentHeight || 0) + Spacing.small,
+            ios: Spacing.small,
+          }),
+        },
+      ]}
+    >
+      <StatusBar
+        translucent
+        barStyle="light-content"
+        backgroundColor="transparent"
       />
 
       <FlatList
@@ -353,12 +362,35 @@ export default function TasksScreen() {
             activeFilter={statusFilter}
           />
         )}
+        ListHeaderComponent={() => [
+          <View key="stats" style={{ marginBottom: Spacing.small }}>
+            <StatsHeader />
+          </View>,
+          <FilterBar
+            key="filter"
+            filters={statusFilters}
+            active={statusFilter}
+            onSelect={setStatusFilter}
+          />,
+          <SearchBar
+            key="search"
+            value={searchQuery}
+            onChange={setSearchQuery}
+            onToggleAdvanced={() => setFiltersVisible(true)}
+          />,
+        ]}
+        stickyHeaderIndices={[1]}
         contentContainerStyle={{
-          paddingHorizontal: Spacing.base,
-          paddingTop: Spacing.base,
-          paddingBottom: 120,
+          paddingHorizontal: Spacing.large,
+          paddingTop: Spacing.small + Spacing.tiny,
+          paddingBottom: Spacing.xlarge * 2,
         }}
         keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+        removeClippedSubviews={true}
+        initialNumToRender={8}
+        windowSize={11}
+        contentInsetAdjustmentBehavior="automatic"
         accessibilityRole="list"
       />
 


### PR DESCRIPTION
## Summary
- Guard TaskScreen with StatusBar-aware SafeArea and sticky filter bar header
- Tokenize search field, filter chips and task cards for consistent dark theme
- Add press feedback and accessibility labels to interactive task UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cf4fd33808327b3f7d4077d1a4f65