### PR TITLE
refactor: restructure tasks layout and filters

### DIFF
--- a/src/components/AddTaskButton/AddTaskButton.js
+++ b/src/components/AddTaskButton/AddTaskButton.js
@@ -1,30 +1,29 @@
 // [MB] Módulo: Tasks / Sección: AddTaskButton
 // Afecta: creación de tareas (botón flotante)
 // Propósito: Botón flotante para agregar tareas nuevas
-// Puntos de edición futura: animaciones y estilos de gradiente
+// Puntos de edición futura: animaciones y estado presionado
 // Autor: Codex - Fecha: 2025-08-13
 
 import React, { useState } from "react";
 import { TouchableOpacity } from "react-native";
-import { LinearGradient } from "expo-linear-gradient";
 import { FontAwesome } from "@expo/vector-icons";
-import styles from "./AddTaskButton.styles";
-import { Colors, Gradients } from "../../theme";
+import styles, { FAB_SIZE } from "./AddTaskButton.styles";
+import { Colors } from "../../theme";
+
+export { FAB_SIZE };
 
 export default function AddTaskButton({ onPress }) {
   const [isPressed, setIsPressed] = useState(false);
   return (
     <TouchableOpacity
-      style={[styles.fab, isPressed && styles.fabShadowPressed]}
+      style={[styles.fab, isPressed && styles.fabPressed]}
       onPress={onPress}
       onPressIn={() => setIsPressed(true)}
       onPressOut={() => setIsPressed(false)}
       accessibilityRole="button"
       accessibilityLabel="Añadir tarea"
     >
-      <LinearGradient colors={Gradients.mana} style={styles.gradient}>
-        <FontAwesome name="plus" size={20} color={Colors.text} />
-      </LinearGradient>
+      <FontAwesome name="plus" size={20} color={Colors.onAccent} />
     </TouchableOpacity>
   );
 }

--- a/src/components/AddTaskButton/AddTaskButton.styles.js
+++ b/src/components/AddTaskButton/AddTaskButton.styles.js
@@ -1,32 +1,28 @@
-// src/components/AddTaskButton/AddTaskButton.styles.js
+// [MB] Módulo: Tasks / Sección: AddTaskButton estilos
+// Afecta: AddTaskButton
+// Propósito: Estilos del botón flotante de nueva tarea
+// Puntos de edición futura: animaciones y posicionamiento
+// Autor: Codex - Fecha: 2025-08-13
 
 import { StyleSheet } from "react-native";
-import { Colors, Spacing } from "../../theme";
+import { Colors, Spacing, Elevation } from "../../theme";
+
+export const FAB_SIZE = 60;
 
 export default StyleSheet.create({
   fab: {
     position: "absolute",
-    bottom: 100,
+    bottom: Spacing.large,
     right: Spacing.large,
-    width: 60,
-    height: 60,
-    borderRadius: 30,
-    overflow: "hidden", // Importante para que el degradado no se salga del borde redondeado
-    shadowColor: Colors.shadow,
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.3,
-    shadowRadius: 6,
-    elevation: 8,
+    width: FAB_SIZE,
+    height: FAB_SIZE,
+    borderRadius: FAB_SIZE / 2,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: Colors.accent,
+    ...Elevation.raised,
   },
-  fabShadowPressed: {
-    shadowOpacity: 0.5,
-    shadowRadius: 10,
-    elevation: 12,
-  },
-  // ¡Aquí es donde debes asegurarte de que estén estas propiedades!
-  gradient: {
-    flex: 1, // Esto asegura que el degradado ocupe todo el espacio del botón.
-    justifyContent: "center", // Centra el contenido (el icono) verticalmente.
-    alignItems: "center", // Centra el contenido (el icono) horizontalmente.
+  fabPressed: {
+    opacity: 0.85,
   },
 });

--- a/src/components/FilterBar/FilterBar.js
+++ b/src/components/FilterBar/FilterBar.js
@@ -5,62 +5,30 @@
 // Autor: Codex - Fecha: 2025-08-13
 
 import React from "react";
-import { View, ScrollView, Pressable, Text } from "react-native";
-import { FontAwesome5, FontAwesome } from "@expo/vector-icons";
-// Los estilos de la barra de filtros residen en FilterBar.styles.js
+import { View, Pressable, Text } from "react-native";
 import styles from "./FilterBar.styles";
-import { Colors, Spacing } from "../../theme";
 
 export default function FilterBar({ filters, active, onSelect }) {
   return (
-    <View style={styles.wrapper}>
-      <View style={styles.glassBar}>
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          style={styles.container}
-          contentContainerStyle={styles.contentContainer}
-        >
-          {filters.map((f) => {
-            const Icon = ["single", "completed", "deleted"].includes(f.key)
-              ? FontAwesome
-              : FontAwesome5;
-            const isActive = active === f.key;
-            return (
-              <Pressable
-                key={f.key}
-                style={({ pressed }) => [
-                  styles.tab,
-                  isActive && styles.tabActive,
-                  pressed && { opacity: 0.9 },
-                ]}
-                onPress={() => onSelect(f.key)}
-                accessibilityRole="button"
-                accessibilityLabel={`Filtrar por ${f.label}`}
-                accessibilityState={{ selected: isActive }}
-                hitSlop={{
-                  top: Spacing.small,
-                  bottom: Spacing.small,
-                  left: Spacing.small,
-                  right: Spacing.small,
-                }}
-              >
-                <Icon
-                  name={f.icon}
-                  size={14}
-                  color={isActive ? Colors.background : Colors.textMuted}
-                  style={styles.icon}
-                />
-                <Text
-                  style={[styles.tabLabel, !isActive && styles.tabLabelInactive]}
-                >
-                  {f.label}
-                </Text>
-              </Pressable>
-            );
-          })}
-        </ScrollView>
-      </View>
+    <View style={styles.container}>
+      {filters.map((f) => {
+        const isActive = active === f.key;
+        return (
+          <Pressable
+            key={f.key}
+            style={[styles.button, isActive ? styles.buttonActive : styles.buttonInactive]}
+            onPress={() => onSelect(f.key)}
+            accessibilityRole="button"
+            accessibilityState={{ selected: isActive }}
+          >
+            <Text
+              style={[styles.label, isActive ? styles.labelActive : styles.labelInactive]}
+            >
+              {f.label}
+            </Text>
+          </Pressable>
+        );
+      })}
     </View>
   );
 }

--- a/src/components/FilterBar/FilterBar.styles.js
+++ b/src/components/FilterBar/FilterBar.styles.js
@@ -1,66 +1,44 @@
 // [MB] Módulo: Tasks / Sección: Barra de filtros
 // Afecta: FilterBar (tabs principales)
-// Propósito: Estilos de tabs y contenedor
-// Puntos de edición futura: scroll y variantes
+// Propósito: Estilos de control segmentado para estado de tareas
+// Puntos de edición futura: animaciones y accesibilidad
 // Autor: Codex - Fecha: 2025-08-13
+
 import { StyleSheet } from "react-native";
 import { Colors, Spacing, Radii } from "../../theme";
 
 export default StyleSheet.create({
-  // wrapper externo para margen
-  wrapper: {
+  container: {
+    flexDirection: "row",
+    backgroundColor: Colors.surfaceElevated,
+    borderRadius: Radii.lg,
+    padding: Spacing.tiny,
+    gap: Spacing.tiny,
     marginVertical: Spacing.small,
   },
-
-  // barra contenedora
-  glassBar: {
-    flexDirection: "row",
-    alignItems: "center",
-    backgroundColor: Colors.surface,
+  button: {
+    flex: 1,
+    height: 40,
     borderRadius: Radii.lg,
-    paddingHorizontal: Spacing.base,
-    minHeight: 40,
-    borderWidth: 1,
-    borderColor: Colors.separator,
-  },
-
-  // Scroll horizontal
-  container: {
-    flexGrow: 0,
-  },
-  contentContainer: {
-    flexGrow: 1,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-
-  // tab individual
-  tab: {
-    flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
-    paddingHorizontal: Spacing.base,
-    height: 36,
-    borderRadius: Radii.pill,
-    borderWidth: 1,
-    borderColor: Colors.separator,
-    backgroundColor: Colors.surfaceElevated,
-    marginRight: Spacing.small,
   },
-  tabActive: {
+  buttonActive: {
     backgroundColor: Colors.accent,
-    borderColor: Colors.accent,
   },
-  icon: {
-    marginRight: Spacing.small,
+  buttonInactive: {
+    backgroundColor: Colors.surface,
+    borderWidth: 1,
+    borderColor: Colors.separator,
   },
-  tabLabel: {
+  label: {
     fontSize: 14,
     fontWeight: "600",
-    color: Colors.background,
-    textAlign: "center",
   },
-  tabLabelInactive: {
+  labelActive: {
+    color: Colors.onAccent,
+  },
+  labelInactive: {
     color: Colors.textMuted,
   },
 });

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -1,21 +1,20 @@
-// src/components/SearchBar/SearchBar.js
+// [MB] Módulo: Tasks / Sección: Barra de búsqueda
+// Afecta: SearchBar
+// Propósito: Campo de búsqueda con acceso a filtros avanzados
+// Puntos de edición futura: estados de focus y validaciones
+// Autor: Codex - Fecha: 2025-08-13
 
 import React from "react";
 import { View, TextInput, TouchableOpacity } from "react-native";
 import { FontAwesome5 } from "@expo/vector-icons";
 import styles from "./SearchBar.styles";
-import { Colors, Spacing } from "../../theme";
+import { Colors } from "../../theme";
 
 export default function SearchBar({ value, onChange, onToggleAdvanced }) {
   return (
     <View style={styles.container}>
       <View style={styles.inner}>
-        <FontAwesome5
-          name="search"
-          size={16}
-          color={Colors.textMuted}
-          style={{ marginRight: Spacing.small }}
-        />
+        <FontAwesome5 name="search" size={16} color={Colors.textMuted} />
         <TextInput
           style={styles.input}
           placeholder="Buscar tareas..."

--- a/src/components/SearchBar/SearchBar.styles.js
+++ b/src/components/SearchBar/SearchBar.styles.js
@@ -14,8 +14,7 @@ export default StyleSheet.create({
     backgroundColor: Colors.surfaceElevated,
     paddingHorizontal: Spacing.base,
     borderRadius: Radii.lg,
-    marginTop: Spacing.small,
-    marginBottom: Spacing.small,
+    marginVertical: Spacing.small,
     justifyContent: "space-between",
     minHeight: 48,
     borderWidth: 1,
@@ -25,6 +24,7 @@ export default StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     flex: 1,
+    gap: Spacing.small,
   },
   input: {
     flex: 1,
@@ -34,7 +34,7 @@ export default StyleSheet.create({
   },
   button: {
     // Botón para filtros avanzados
-    marginLeft: Spacing.base,
+    marginLeft: Spacing.small,
     opacity: 0.9,
   },
 });

--- a/src/components/SwipeableTaskItem/SwipeableTaskItem.js
+++ b/src/components/SwipeableTaskItem/SwipeableTaskItem.js
@@ -326,14 +326,10 @@ export default function SwipeableTaskItem({
           </>
         )}
 
-        {/* ——— Badges de Elemento y Tipo ——— */}
-        <View style={styles.badgeRow}>
-          {/* Elemento (solo icono) */}
+        {/* ——— Chips de metadatos ——— */}
+        <View style={styles.chipRow}>
           <View
-            style={[
-              styles.elementBadge,
-              { backgroundColor: elementInfo.color },
-            ]}
+            style={[styles.elementChip, { backgroundColor: elementInfo.color }]}
             accessible
             accessibilityLabel={`Elemento ${elementInfo.label}`}
           >
@@ -343,21 +339,21 @@ export default function SwipeableTaskItem({
               color={Colors.background}
             />
           </View>
-          {/* Tipo */}
-          <View style={[styles.badge, { backgroundColor: typeConfig.color }]}>
-            <Text style={[styles.badgeText, { color: Colors.text }]}>
+          <View style={[styles.chip, { backgroundColor: typeConfig.color }]}>
+            <Text style={[styles.chipText, styles.typeChipText]}>
               {typeConfig.label}
             </Text>
           </View>
-          {/* Prioridad (chip con borde) */}
           <View
             style={[
+              styles.chip,
               styles.priorityChip,
               { borderColor: getPriorityColor(task.priority) },
             ]}
           >
             <Text
               style={[
+                styles.chipText,
                 styles.priorityChipText,
                 { color: getPriorityColor(task.priority) },
               ]}
@@ -365,18 +361,12 @@ export default function SwipeableTaskItem({
               {getPriorityLabel(task.priority)}
             </Text>
           </View>
+          {task.tags?.map((tag) => (
+            <View key={tag} style={[styles.chip, styles.tagChip]}>
+              <Text style={styles.chipText}>{tag}</Text>
+            </View>
+          ))}
         </View>
-
-        {/* Etiquetas de la tarea */}
-        {task.tags?.length > 0 && (
-          <View style={styles.tagContainer}>
-            {task.tags.map((tag) => (
-              <View key={tag} style={styles.tagChip}>
-                <Text style={styles.tagText}>{tag}</Text>
-              </View>
-            ))}
-          </View>
-        )}
       </Animated.View>
     </View>
   );

--- a/src/components/SwipeableTaskItem/SwipeableTaskItem.styles.js
+++ b/src/components/SwipeableTaskItem/SwipeableTaskItem.styles.js
@@ -124,75 +124,42 @@ export default StyleSheet.create({
     textDecorationLine: "line-through",
   },
 
-  // etiquetas (chips) existentes:
-  tagContainer: {
+  chipRow: {
     flexDirection: "row",
     flexWrap: "wrap",
-    marginTop: Spacing.small,
+    alignItems: "center",
+    gap: Spacing.tiny,
+    marginTop: Spacing.tiny,
+  },
+  elementChip: {
+    width: 24,
+    height: 24,
+    borderRadius: Radii.pill,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  chip: {
+    minHeight: 24,
+    paddingHorizontal: Spacing.small,
+    borderRadius: Radii.pill,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  chipText: {
+    ...Typography.caption,
+    lineHeight: Typography.caption.fontSize,
+    color: Colors.text,
+  },
+  typeChipText: {
+    transform: [{ scale: 0.95 }],
+  },
+  priorityChip: {
+    borderWidth: StyleSheet.hairlineWidth,
   },
   tagChip: {
     backgroundColor: Colors.surface,
-    borderRadius: Radii.pill,
-    paddingHorizontal: Spacing.small,
-    paddingVertical: Spacing.tiny,
-    marginRight: Spacing.tiny,
-    marginTop: Spacing.tiny,
-  },
-  tagText: {
-    ...Typography.caption,
-    color: Colors.text,
-  },
-
-  // badge de elemento (círculo con icono)
-  elementBadge: {
-    width: 22,
-    height: 22,
-    borderRadius: 8,
-    alignItems: "center",
-    justifyContent: "center",
-    marginRight: Spacing.small,
-    marginTop: 1,
-    // opcional: un poco de relieve
-    shadowColor: Colors.shadow,
-
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.2,
-    shadowRadius: 1.5,
-    elevation: 2,
-  },
-
-  // badges de dificultad:
-  badgeRow: {
-    flexDirection: "row",
-    marginTop: Spacing.small,
-  },
-  badge: {
-    flexDirection: "row",
-    alignItems: "center",
-    borderRadius: Radii.md,
-    paddingHorizontal: Spacing.small,
-    paddingVertical: Spacing.tiny,
-    marginRight: Spacing.small,
-    marginTop: Spacing.tiny,
-  },
-  badgeIcon: {
-    marginRight: Spacing.tiny,
-  },
-  badgeText: {
-    ...Typography.caption,
-    fontWeight: "600",
-  },
-  // chip de prioridad:
-  priorityChip: {
-    borderRadius: Radii.pill,
-    paddingHorizontal: Spacing.small,
-    paddingVertical: Spacing.tiny,
-    justifyContent: "center",
-    alignItems: "center",
-    borderWidth: StyleSheet.hairlineWidth,
   },
   priorityChipText: {
-    ...Typography.caption,
     fontWeight: "500",
     textTransform: "capitalize",
   },

--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -4,22 +4,16 @@
 // Puntos de edición futura: manejo remoto y estilos de filtros
 // Autor: Codex - Fecha: 2025-08-13
 
-import React, { useState, useEffect } from "react";
-import {
-  SafeAreaView,
-  FlatList,
-  Modal,
-  View,
-  StatusBar,
-  Platform,
-} from "react-native";
+import React, { useState, useEffect, useMemo } from "react";
+import { SafeAreaView, FlatList, Modal, View, StatusBar } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { getTasks as getStoredTasks, setTasks as setStoredTasks } from "../storage";
 
 import StatsHeader from "../components/StatsHeader";
 import SearchBar from "../components/SearchBar/SearchBar";
 import TaskFilters from "../components/TaskFilters";
 import SwipeableTaskItem from "../components/SwipeableTaskItem/SwipeableTaskItem";
-import AddTaskButton from "../components/AddTaskButton/AddTaskButton";
+import AddTaskButton, { FAB_SIZE } from "../components/AddTaskButton/AddTaskButton";
 import FilterBar from "../components/FilterBar/FilterBar";
 import styles from "./TasksScreen.styles";
 import { Colors, Spacing } from "../theme";
@@ -146,16 +140,16 @@ const elementInfo = {
 
 export default function TasksScreen() {
   const dispatch = useAppDispatch();
+  const insets = useSafeAreaInsets();
   // ——— 2) Estados ———
   const [tasks, setTasks] = useState([]);
   const uniqueTags = Array.from(new Set(tasks.flatMap((t) => t.tags || [])));
-  // useState para manejar el estado de los filtros
-  const [activeFilter, setActiveFilter] = useState("all");
+  const [typeFilter, setTypeFilter] = useState("all");
   const [elementFilter, setElementFilter] = useState("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [priorityFilter, setPriorityFilter] = useState("all");
   const [tagFilter, setTagFilter] = useState("all");
-  const [statusFilter, setStatusFilter] = useState("pending");
+  const [activeFilter, setActiveFilter] = useState("pending");
   const [filtersVisible, setFiltersVisible] = useState(false); // BottomSheet de filtros
   const [showAddModal, setShowAddModal] = useState(false); // Para el botón de añadir tarea
   const [editingTask, setEditingTask] = useState(null);
@@ -300,47 +294,53 @@ export default function TasksScreen() {
   };
 
   // ——— 4) Filtrado combinado ———
-  const filteredTasks = tasks.filter((task) => {
-    let stateOK;
-    switch (statusFilter) {
-      case "completed":
-        stateOK = task.done && !task.isDeleted;
-        break;
-      case "deleted":
-        stateOK = task.isDeleted;
-        break;
-      default:
-        stateOK = !task.done && !task.isDeleted;
-    }
-    const typeOK = activeFilter === "all" || task.type === activeFilter;
-    const elementOK = elementFilter === "all" || task.element === elementFilter;
-    const q = searchQuery.toLowerCase();
-    const searchOK =
-      task.title.toLowerCase().includes(q) ||
-      task.note.toLowerCase().includes(q);
-    const prioOK = priorityFilter === "all" || task.priority === priorityFilter;
-    const tagOK = tagFilter === "all" || (task.tags || []).includes(tagFilter);
-    const diffOK =
-      difficultyFilter === "all" || task.difficulty === difficultyFilter;
+  const filteredTasks = useMemo(() => {
+    return tasks.filter((task) => {
+      let stateOK;
+      switch (activeFilter) {
+        case "completed":
+          stateOK = task.done && !task.isDeleted;
+          break;
+        case "deleted":
+          stateOK = task.isDeleted;
+          break;
+        default:
+          stateOK = !task.done && !task.isDeleted;
+      }
+      const typeOK = typeFilter === "all" || task.type === typeFilter;
+      const elementOK = elementFilter === "all" || task.element === elementFilter;
+      const q = searchQuery.toLowerCase();
+      const searchOK =
+        task.title.toLowerCase().includes(q) ||
+        task.note.toLowerCase().includes(q);
+      const prioOK = priorityFilter === "all" || task.priority === priorityFilter;
+      const tagOK = tagFilter === "all" || (task.tags || []).includes(tagFilter);
+      const diffOK =
+        difficultyFilter === "all" || task.difficulty === difficultyFilter;
 
-    return (
-      stateOK && typeOK && elementOK && searchOK && prioOK && tagOK && diffOK
-    );
-  });
+      return (
+        stateOK && typeOK && elementOK && searchOK && prioOK && tagOK && diffOK
+      );
+    });
+  }, [
+    tasks,
+    activeFilter,
+    typeFilter,
+    elementFilter,
+    searchQuery,
+    priorityFilter,
+    tagFilter,
+    difficultyFilter,
+  ]);
 
   // ——— 5) Render ———
+  const listData = useMemo(
+    () => [{ renderType: "filters" }, ...filteredTasks],
+    [filteredTasks]
+  );
+
   return (
-    <SafeAreaView
-      style={[
-        styles.container,
-        {
-          paddingTop: Platform.select({
-            android: (StatusBar.currentHeight || 0) + Spacing.small,
-            ios: Spacing.small,
-          }),
-        },
-      ]}
-    >
+    <SafeAreaView style={[styles.container, { paddingTop: insets.top }]}>
       <StatusBar
         translucent
         barStyle="light-content"
@@ -348,49 +348,59 @@ export default function TasksScreen() {
       />
 
       <FlatList
-        data={filteredTasks}
-        keyExtractor={(item) => item.id.toString()}
-        renderItem={({ item }) => (
-          <SwipeableTaskItem
-            task={item}
-            onToggleComplete={toggleTaskDone}
-            onSoftDeleteTask={onSoftDeleteTask}
-            onRestoreTask={onRestoreTask}
-            onPermanentDeleteTask={onPermanentDeleteTask}
-            onEditTask={onEditTask}
-            onToggleSubtask={onToggleSubtask}
-            activeFilter={statusFilter}
-          />
-        )}
-        ListHeaderComponent={() => [
-          <View key="stats" style={{ marginBottom: Spacing.small }}>
-            <StatsHeader />
-          </View>,
-          <FilterBar
-            key="filter"
-            filters={statusFilters}
-            active={statusFilter}
-            onSelect={setStatusFilter}
-          />,
-          <SearchBar
-            key="search"
-            value={searchQuery}
-            onChange={setSearchQuery}
-            onToggleAdvanced={() => setFiltersVisible(true)}
-          />,
-        ]}
-        stickyHeaderIndices={[1]}
+        data={listData}
+        keyExtractor={(item) => item.id || item.renderType}
+        renderItem={({ item }) =>
+          item.renderType === "filters" ? (
+            <FilterBar
+              filters={statusFilters}
+              active={activeFilter}
+              onSelect={setActiveFilter}
+            />
+          ) : (
+            <SwipeableTaskItem
+              task={item}
+              onToggleComplete={toggleTaskDone}
+              onSoftDeleteTask={onSoftDeleteTask}
+              onRestoreTask={onRestoreTask}
+              onPermanentDeleteTask={onPermanentDeleteTask}
+              onEditTask={onEditTask}
+              onToggleSubtask={onToggleSubtask}
+              activeFilter={activeFilter}
+            />
+          )
+        }
+        ListHeaderComponent={
+          <>
+            <View style={{ marginVertical: Spacing.small }}>
+              <StatsHeader />
+            </View>
+            <View style={{ marginVertical: Spacing.small }}>
+              <SearchBar
+                value={searchQuery}
+                onChange={setSearchQuery}
+                onToggleAdvanced={() => setFiltersVisible(true)}
+              />
+            </View>
+          </>
+        }
+        stickyHeaderIndices={[0]}
         contentContainerStyle={{
           paddingHorizontal: Spacing.large,
-          paddingTop: Spacing.small + Spacing.tiny,
-          paddingBottom: Spacing.xlarge * 2,
+          paddingTop: Spacing.base,
         }}
+        ListFooterComponent={
+          <View
+            style={{ height: FAB_SIZE + insets.bottom + Spacing.large }}
+          />
+        }
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
-        removeClippedSubviews={true}
+        removeClippedSubviews={false}
         initialNumToRender={8}
         windowSize={11}
         contentInsetAdjustmentBehavior="automatic"
+        extraData={{ tasks, activeFilter, searchQuery }}
         accessibilityRole="list"
       />
 
@@ -417,7 +427,7 @@ export default function TasksScreen() {
                 difficultyFilter,
                 tagFilter,
               }) => {
-                setActiveFilter(active);
+                setTypeFilter(active);
                 setElementFilter(elementFilter);
                 setPriorityFilter(priorityFilter);
                 setDifficultyFilter(difficultyFilter);

--- a/src/screens/TasksScreen.styles.js
+++ b/src/screens/TasksScreen.styles.js
@@ -5,7 +5,7 @@
 // Autor: Codex - Fecha: 2025-08-13
 
 import { StyleSheet } from "react-native";
-import { Colors, Spacing } from "../theme";
+import { Colors, Spacing, Radii } from "../theme";
 
 export default StyleSheet.create({
   container: {
@@ -14,14 +14,14 @@ export default StyleSheet.create({
   },
   filterModalBackground: {
     flex: 1,
-    backgroundColor: "rgba(0,0,0,0.5)",
+    backgroundColor: Colors.overlay,
     justifyContent: "center",
     alignItems: "center",
   },
   filterModalContainer: {
     width: "90%",
     backgroundColor: Colors.surface,
-    borderRadius: 12,
+    borderRadius: Radii.md,
     padding: Spacing.base,
     maxHeight: "90%",
   },

--- a/src/theme.js
+++ b/src/theme.js
@@ -23,6 +23,7 @@ export const Colors = {
   secondary: "#1cd47bff", // Turquesa etéreo (con alpha)
   secondaryLight: "#80deea",
   accent: "#ffca28", // Dorado suave para acentos
+  onAccent: "#0e0a1e",
 
   // Fantasía (gradientes/decor)
   primaryFantasy: "#B542F6",


### PR DESCRIPTION
## Summary
- refactor task screen with sticky segmented filter and safe-area padding
- align task chips and floating action button to theme tokens
- add onAccent color token

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cf9b248fc832791263898ca459a37