### PR TITLE
Refine task screen layout and FAB

### DIFF
--- a/src/components/TaskCard/TaskCard.js
+++ b/src/components/TaskCard/TaskCard.js
@@ -1,8 +1,8 @@
-// [MB] Módulo: Tasks / Sección: Tarea swipeable
+// [MB] Módulo: Tasks / Sección: Tarjeta de tarea
 // Afecta: TasksScreen (interacción de completar y eliminar tareas)
 // Propósito: Item de tarea deslizable con acciones y recompensas
-// Puntos de edición futura: animaciones y estilos en SwipeableTaskItem
-// Autor: Codex - Fecha: 2025-08-12
+// Puntos de edición futura: animaciones y estilos en TaskCard
+// Autor: Codex - Fecha: 2025-08-13
 
 import React, { useRef, useState } from "react";
 import {
@@ -13,7 +13,7 @@ import {
   PanResponder,
 } from "react-native";
 import { FontAwesome5 } from "@expo/vector-icons";
-import styles from "./SwipeableTaskItem.styles";
+import styles from "./TaskCard.styles";
 import { Colors, Spacing } from "../../theme";
 
 const getElementColor = (element) => {
@@ -69,7 +69,7 @@ const getTypeConfig = (type) => {
   }
 };
 
-export default function SwipeableTaskItem({
+export default function TaskCard({
   task,
   onToggleComplete,
   onSoftDeleteTask,
@@ -186,17 +186,19 @@ export default function SwipeableTaskItem({
       {/* task content */}
       <Animated.View
         style={[
-          styles.taskItem,
+          styles.card,
           {
             transform: [{ translateX: pan }, { scale }],
             opacity: task.completed || task.isDeleted ? 0.5 : 1,
-            borderLeftColor: getPriorityColor(task.priority),
           },
         ]}
         {...panResponder.panHandlers}
         onTouchStart={handlePressIn}
         onTouchEnd={handlePressOut}
       >
+        <View
+          style={[styles.accentBar, { backgroundColor: elementInfo.color }]}
+        />
         <TouchableOpacity
           style={styles.contentRow}
           onPress={() => onEditTask(task)}
@@ -327,7 +329,7 @@ export default function SwipeableTaskItem({
         )}
 
         {/* ——— Chips de metadatos ——— */}
-        <View style={styles.chipRow}>
+        <View style={styles.metaRow}>
           <View
             style={[styles.elementChip, { backgroundColor: elementInfo.color }]}
             accessible
@@ -339,8 +341,8 @@ export default function SwipeableTaskItem({
               color={Colors.background}
             />
           </View>
-          <View style={[styles.chip, { backgroundColor: typeConfig.color }]}>
-            <Text style={[styles.chipText, styles.typeChipText]}>
+          <View style={[styles.chip, { backgroundColor: typeConfig.color }]}> 
+            <Text style={styles.chipText}>
               {typeConfig.label}
             </Text>
           </View>
@@ -361,12 +363,16 @@ export default function SwipeableTaskItem({
               {getPriorityLabel(task.priority)}
             </Text>
           </View>
-          {task.tags?.map((tag) => (
-            <View key={tag} style={[styles.chip, styles.tagChip]}>
-              <Text style={styles.chipText}>{tag}</Text>
-            </View>
-          ))}
         </View>
+        {task.tags?.length > 0 && (
+          <View style={[styles.metaRow, styles.labelRow]}>
+            {task.tags.map((tag) => (
+              <View key={tag} style={[styles.chip, styles.tagChip]}>
+                <Text style={styles.chipText}>{tag}</Text>
+              </View>
+            ))}
+          </View>
+        )}
       </Animated.View>
     </View>
   );

--- a/src/components/TaskCard/TaskCard.styles.js
+++ b/src/components/TaskCard/TaskCard.styles.js
@@ -1,5 +1,5 @@
-// [MB] Módulo: Tasks / Sección: Tarea swipeable
-// Afecta: SwipeableTaskItem
+// [MB] Módulo: Tasks / Sección: Tarjeta de tarea
+// Afecta: TaskCard
 // Propósito: estilos de tarjeta y chips
 // Puntos de edición futura: animaciones y badges
 // Autor: Codex - Fecha: 2025-08-13
@@ -14,9 +14,7 @@ import {
 } from "../../theme";
 
 export default StyleSheet.create({
-  container: {
-    marginVertical: Spacing.small,
-  },
+  container: {},
   actionsOverlay: {
     ...StyleSheet.absoluteFillObject,
     flexDirection: "row",
@@ -49,12 +47,22 @@ export default StyleSheet.create({
     marginTop: Spacing.tiny,
     fontSize: 12,
   },
-  taskItem: {
+  card: {
+    width: "100%",
     backgroundColor: Colors.surfaceElevated,
     borderRadius: Radii.lg,
-    padding: Spacing.small + Spacing.tiny,
-    borderLeftWidth: Spacing.tiny / 2,
+    paddingRight: Spacing.base,
+    paddingVertical: Spacing.base,
+    paddingLeft: Spacing.large,
+    marginVertical: Spacing.small,
     ...Elevation.card,
+  },
+  accentBar: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+    bottom: 0,
+    width: Spacing.tiny,
   },
   contentRow: {
     flexDirection: "row",
@@ -62,7 +70,6 @@ export default StyleSheet.create({
   },
   textContainer: {
     flex: 1,
-    marginLeft: 1,
   },
   title: {
     ...Typography.title,
@@ -124,11 +131,13 @@ export default StyleSheet.create({
     textDecorationLine: "line-through",
   },
 
-  chipRow: {
+  metaRow: {
     flexDirection: "row",
     flexWrap: "wrap",
     alignItems: "center",
     gap: Spacing.tiny,
+  },
+  labelRow: {
     marginTop: Spacing.tiny,
   },
   elementChip: {
@@ -150,14 +159,12 @@ export default StyleSheet.create({
     lineHeight: Typography.caption.fontSize,
     color: Colors.text,
   },
-  typeChipText: {
-    transform: [{ scale: 0.95 }],
-  },
   priorityChip: {
     borderWidth: StyleSheet.hairlineWidth,
   },
   tagChip: {
     backgroundColor: Colors.surface,
+    transform: [{ scale: 0.95 }],
   },
   priorityChipText: {
     fontWeight: "500",

--- a/src/components/TaskFilterBar/TaskFilterBar.js
+++ b/src/components/TaskFilterBar/TaskFilterBar.js
@@ -1,14 +1,14 @@
 // [MB] Módulo: Tasks / Sección: Barra de filtros
-// Afecta: FilterBar (tabs principales)
+// Afecta: TaskFilterBar (tabs principales)
 // Propósito: Tabs accesibles alineadas al tema
 // Puntos de edición futura: animaciones y desplazamiento
 // Autor: Codex - Fecha: 2025-08-13
 
 import React from "react";
 import { View, Pressable, Text } from "react-native";
-import styles from "./FilterBar.styles";
+import styles from "./TaskFilterBar.styles";
 
-export default function FilterBar({ filters, active, onSelect }) {
+export default function TaskFilterBar({ filters, active, onSelect }) {
   return (
     <View style={styles.container}>
       {filters.map((f) => {

--- a/src/components/TaskFilterBar/TaskFilterBar.styles.js
+++ b/src/components/TaskFilterBar/TaskFilterBar.styles.js
@@ -1,20 +1,22 @@
 // [MB] Módulo: Tasks / Sección: Barra de filtros
-// Afecta: FilterBar (tabs principales)
+// Afecta: TaskFilterBar (tabs principales)
 // Propósito: Estilos de control segmentado para estado de tareas
 // Puntos de edición futura: animaciones y accesibilidad
 // Autor: Codex - Fecha: 2025-08-13
 
 import { StyleSheet } from "react-native";
-import { Colors, Spacing, Radii } from "../../theme";
+import { Colors, Spacing, Radii, Elevation } from "../../theme";
 
 export default StyleSheet.create({
   container: {
     flexDirection: "row",
-    backgroundColor: Colors.surfaceElevated,
+    backgroundColor: Colors.surface,
     borderRadius: Radii.lg,
-    padding: Spacing.tiny,
+    paddingHorizontal: Spacing.tiny,
+    paddingVertical: Spacing.tiny,
     gap: Spacing.tiny,
-    marginVertical: Spacing.small,
+    zIndex: 50,
+    ...Elevation.raised,
   },
   button: {
     flex: 1,

--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -5,16 +5,24 @@
 // Autor: Codex - Fecha: 2025-08-13
 
 import React, { useState, useEffect, useMemo } from "react";
-import { SafeAreaView, FlatList, Modal, View, StatusBar } from "react-native";
+import {
+  SafeAreaView,
+  FlatList,
+  Modal,
+  View,
+  StatusBar,
+  TouchableOpacity,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
+import { FontAwesome } from "@expo/vector-icons";
 import { getTasks as getStoredTasks, setTasks as setStoredTasks } from "../storage";
 
 import StatsHeader from "../components/StatsHeader";
 import SearchBar from "../components/SearchBar/SearchBar";
 import TaskFilters from "../components/TaskFilters";
-import SwipeableTaskItem from "../components/SwipeableTaskItem/SwipeableTaskItem";
-import AddTaskButton, { FAB_SIZE } from "../components/AddTaskButton/AddTaskButton";
-import FilterBar from "../components/FilterBar/FilterBar";
+import TaskCard from "../components/TaskCard/TaskCard";
+import TaskFilterBar from "../components/TaskFilterBar/TaskFilterBar";
 import styles from "./TasksScreen.styles";
 import { Colors, Spacing } from "../theme";
 import CreateTaskModal from "../components/CreateTaskModal/CreateTaskModal";
@@ -141,6 +149,8 @@ const elementInfo = {
 export default function TasksScreen() {
   const dispatch = useAppDispatch();
   const insets = useSafeAreaInsets();
+  const tabBarHeight = useBottomTabBarHeight?.() ?? 56;
+  const fabOffset = tabBarHeight + insets.bottom + Spacing.large;
   // ——— 2) Estados ———
   const [tasks, setTasks] = useState([]);
   const uniqueTags = Array.from(new Set(tasks.flatMap((t) => t.tags || [])));
@@ -358,11 +368,13 @@ export default function TasksScreen() {
         renderItem={({ item }) => {
           if (item.renderType === "filters") {
             return (
-              <FilterBar
-                filters={statusFilters}
-                active={activeFilter}
-                onSelect={setActiveFilter}
-              />
+              <View style={{ backgroundColor: Colors.surface }}>
+                <TaskFilterBar
+                  filters={statusFilters}
+                  active={activeFilter}
+                  onSelect={setActiveFilter}
+                />
+              </View>
             );
           }
           if (item.renderType === "search") {
@@ -377,8 +389,7 @@ export default function TasksScreen() {
             );
           }
           return (
-
-            <SwipeableTaskItem
+            <TaskCard
               task={item}
               onToggleComplete={toggleTaskDone}
               onSoftDeleteTask={onSoftDeleteTask}
@@ -401,11 +412,7 @@ export default function TasksScreen() {
           paddingHorizontal: Spacing.large,
           paddingTop: Spacing.base,
         }}
-        ListFooterComponent={
-          <View
-            style={{ height: FAB_SIZE + insets.bottom + Spacing.large }}
-          />
-        }
+        ListFooterComponent={<View style={{ height: fabOffset + Spacing.large }} />}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
         removeClippedSubviews={false}
@@ -416,7 +423,14 @@ export default function TasksScreen() {
         accessibilityRole="list"
       />
 
-      <AddTaskButton onPress={onAddTask} />
+      <TouchableOpacity
+        style={[styles.fab, { bottom: fabOffset }]}
+        onPress={onAddTask}
+        accessibilityRole="button"
+        accessibilityLabel="Añadir tarea"
+      >
+        <FontAwesome name="plus" size={20} color={Colors.onAccent} />
+      </TouchableOpacity>
 
       <Modal
         visible={filtersVisible}

--- a/src/screens/TasksScreen.styles.js
+++ b/src/screens/TasksScreen.styles.js
@@ -5,7 +5,8 @@
 // Autor: Codex - Fecha: 2025-08-13
 
 import { StyleSheet } from "react-native";
-import { Colors, Spacing, Radii } from "../theme";
+import { Colors, Spacing, Radii, Elevation } from "../theme";
+import { FAB_SIZE } from "../components/AddTaskButton/AddTaskButton.styles";
 
 export default StyleSheet.create({
   container: {
@@ -24,5 +25,18 @@ export default StyleSheet.create({
     borderRadius: Radii.md,
     padding: Spacing.base,
     maxHeight: "90%",
+  },
+  fab: {
+    position: "absolute",
+    right: Spacing.large,
+    width: FAB_SIZE,
+    height: FAB_SIZE,
+    borderRadius: FAB_SIZE / 2,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: Colors.accent,
+    zIndex: 60,
+    ...Elevation.card,
+    elevation: 8,
   },
 });


### PR DESCRIPTION
## Summary
- Align task cards with home padding and add accent bar overlay
- Split task metadata into separate rows and update chip styling
- Elevate sticky filter bar and reposition FAB above tab bar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d04234d188327a3a17d2d718ddcc4