### PR TITLE
Refine task screen layout and FAB

### DIFF
--- a/src/components/FilterBar/FilterBar.js
+++ b/src/components/FilterBar/FilterBar.js
@@ -21,9 +21,7 @@ export default function FilterBar({ filters, active, onSelect }) {
             accessibilityRole="button"
             accessibilityState={{ selected: isActive }}
           >
-            <Text
-              style={[styles.label, isActive ? styles.labelActive : styles.labelInactive]}
-            >
+            <Text style={isActive ? styles.textActive : styles.textInactive}>
               {f.label}
             </Text>
           </Pressable>

--- a/src/components/FilterBar/FilterBar.styles.js
+++ b/src/components/FilterBar/FilterBar.styles.js
@@ -5,16 +5,17 @@
 // Autor: Codex - Fecha: 2025-08-13
 
 import { StyleSheet } from "react-native";
-import { Colors, Spacing, Radii } from "../../theme";
+import { Colors, Spacing, Radii, Typography } from "../../theme";
 
 export default StyleSheet.create({
   container: {
     flexDirection: "row",
-    backgroundColor: Colors.surfaceElevated,
-    borderRadius: Radii.lg,
-    padding: Spacing.tiny,
     gap: Spacing.tiny,
-    marginVertical: Spacing.small,
+    paddingHorizontal: Spacing.large,
+    paddingVertical: Spacing.tiny,
+    backgroundColor: Colors.surface,
+    zIndex: 50,
+    elevation: 4,
   },
   button: {
     flex: 1,
@@ -27,18 +28,17 @@ export default StyleSheet.create({
     backgroundColor: Colors.accent,
   },
   buttonInactive: {
-    backgroundColor: Colors.surface,
+    backgroundColor: Colors.surfaceElevated,
     borderWidth: 1,
     borderColor: Colors.separator,
   },
-  label: {
-    fontSize: 14,
+  textActive: {
+    ...Typography.caption,
+    color: Colors.onAccent,
     fontWeight: "600",
   },
-  labelActive: {
-    color: Colors.onAccent,
-  },
-  labelInactive: {
+  textInactive: {
+    ...Typography.caption,
     color: Colors.textMuted,
   },
 });

--- a/src/components/SwipeableTaskItem/SwipeableTaskItem.js
+++ b/src/components/SwipeableTaskItem/SwipeableTaskItem.js
@@ -1,8 +1,8 @@
-// [MB] Módulo: Tasks / Sección: Tarea swipeable
+// [MB] Módulo: Tasks / Sección: Tarjeta de tarea
 // Afecta: TasksScreen (interacción de completar y eliminar tareas)
 // Propósito: Item de tarea deslizable con acciones y recompensas
 // Puntos de edición futura: animaciones y estilos en SwipeableTaskItem
-// Autor: Codex - Fecha: 2025-08-12
+// Autor: Codex - Fecha: 2025-08-13
 
 import React, { useRef, useState } from "react";
 import {
@@ -186,17 +186,19 @@ export default function SwipeableTaskItem({
       {/* task content */}
       <Animated.View
         style={[
-          styles.taskItem,
+          styles.card,
           {
             transform: [{ translateX: pan }, { scale }],
             opacity: task.completed || task.isDeleted ? 0.5 : 1,
-            borderLeftColor: getPriorityColor(task.priority),
           },
         ]}
         {...panResponder.panHandlers}
         onTouchStart={handlePressIn}
         onTouchEnd={handlePressOut}
       >
+        <View
+          style={[styles.accentBar, { backgroundColor: elementInfo.color }]}
+        />
         <TouchableOpacity
           style={styles.contentRow}
           onPress={() => onEditTask(task)}
@@ -327,7 +329,7 @@ export default function SwipeableTaskItem({
         )}
 
         {/* ——— Chips de metadatos ——— */}
-        <View style={styles.chipRow}>
+        <View style={styles.metaRow}>
           <View
             style={[styles.elementChip, { backgroundColor: elementInfo.color }]}
             accessible
@@ -339,8 +341,8 @@ export default function SwipeableTaskItem({
               color={Colors.background}
             />
           </View>
-          <View style={[styles.chip, { backgroundColor: typeConfig.color }]}>
-            <Text style={[styles.chipText, styles.typeChipText]}>
+          <View style={[styles.chip, { backgroundColor: typeConfig.color }]}> 
+            <Text style={styles.chipText}>
               {typeConfig.label}
             </Text>
           </View>
@@ -361,12 +363,16 @@ export default function SwipeableTaskItem({
               {getPriorityLabel(task.priority)}
             </Text>
           </View>
-          {task.tags?.map((tag) => (
-            <View key={tag} style={[styles.chip, styles.tagChip]}>
-              <Text style={styles.chipText}>{tag}</Text>
-            </View>
-          ))}
         </View>
+        {task.tags?.length > 0 && (
+          <View style={[styles.metaRow, styles.labelRow]}>
+            {task.tags.map((tag) => (
+              <View key={tag} style={[styles.chip, styles.tagChip]}>
+                <Text style={styles.chipText}>{tag}</Text>
+              </View>
+            ))}
+          </View>
+        )}
       </Animated.View>
     </View>
   );

--- a/src/components/SwipeableTaskItem/SwipeableTaskItem.styles.js
+++ b/src/components/SwipeableTaskItem/SwipeableTaskItem.styles.js
@@ -1,4 +1,4 @@
-// [MB] Módulo: Tasks / Sección: Tarea swipeable
+// [MB] Módulo: Tasks / Sección: Tarjeta de tarea
 // Afecta: SwipeableTaskItem
 // Propósito: estilos de tarjeta y chips
 // Puntos de edición futura: animaciones y badges
@@ -14,9 +14,7 @@ import {
 } from "../../theme";
 
 export default StyleSheet.create({
-  container: {
-    marginVertical: Spacing.small,
-  },
+  container: {},
   actionsOverlay: {
     ...StyleSheet.absoluteFillObject,
     flexDirection: "row",
@@ -49,12 +47,21 @@ export default StyleSheet.create({
     marginTop: Spacing.tiny,
     fontSize: 12,
   },
-  taskItem: {
+  card: {
+    width: "100%",
     backgroundColor: Colors.surfaceElevated,
     borderRadius: Radii.lg,
-    padding: Spacing.small + Spacing.tiny,
-    borderLeftWidth: Spacing.tiny / 2,
+    padding: Spacing.base,
+    paddingLeft: Spacing.large,
+    marginVertical: Spacing.small,
     ...Elevation.card,
+  },
+  accentBar: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+    bottom: 0,
+    width: Spacing.tiny,
   },
   contentRow: {
     flexDirection: "row",
@@ -62,7 +69,6 @@ export default StyleSheet.create({
   },
   textContainer: {
     flex: 1,
-    marginLeft: 1,
   },
   title: {
     ...Typography.title,
@@ -124,11 +130,13 @@ export default StyleSheet.create({
     textDecorationLine: "line-through",
   },
 
-  chipRow: {
+  metaRow: {
     flexDirection: "row",
     flexWrap: "wrap",
     alignItems: "center",
     gap: Spacing.tiny,
+  },
+  labelRow: {
     marginTop: Spacing.tiny,
   },
   elementChip: {
@@ -150,14 +158,12 @@ export default StyleSheet.create({
     lineHeight: Typography.caption.fontSize,
     color: Colors.text,
   },
-  typeChipText: {
-    transform: [{ scale: 0.95 }],
-  },
   priorityChip: {
     borderWidth: StyleSheet.hairlineWidth,
   },
   tagChip: {
     backgroundColor: Colors.surface,
+    transform: [{ scale: 0.95 }],
   },
   priorityChipText: {
     fontWeight: "500",

--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -5,15 +5,23 @@
 // Autor: Codex - Fecha: 2025-08-13
 
 import React, { useState, useEffect, useMemo } from "react";
-import { SafeAreaView, FlatList, Modal, View, StatusBar } from "react-native";
+import {
+  SafeAreaView,
+  FlatList,
+  Modal,
+  View,
+  StatusBar,
+  TouchableOpacity,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
+import { FontAwesome } from "@expo/vector-icons";
 import { getTasks as getStoredTasks, setTasks as setStoredTasks } from "../storage";
 
 import StatsHeader from "../components/StatsHeader";
 import SearchBar from "../components/SearchBar/SearchBar";
 import TaskFilters from "../components/TaskFilters";
 import SwipeableTaskItem from "../components/SwipeableTaskItem/SwipeableTaskItem";
-import AddTaskButton, { FAB_SIZE } from "../components/AddTaskButton/AddTaskButton";
 import FilterBar from "../components/FilterBar/FilterBar";
 import styles from "./TasksScreen.styles";
 import { Colors, Spacing } from "../theme";
@@ -141,6 +149,8 @@ const elementInfo = {
 export default function TasksScreen() {
   const dispatch = useAppDispatch();
   const insets = useSafeAreaInsets();
+  const tabBarHeight = useBottomTabBarHeight?.() ?? 56;
+  const fabOffset = tabBarHeight + insets.bottom + Spacing.large;
   // ——— 2) Estados ———
   const [tasks, setTasks] = useState([]);
   const uniqueTags = Array.from(new Set(tasks.flatMap((t) => t.tags || [])));
@@ -358,11 +368,13 @@ export default function TasksScreen() {
         renderItem={({ item }) => {
           if (item.renderType === "filters") {
             return (
-              <FilterBar
-                filters={statusFilters}
-                active={activeFilter}
-                onSelect={setActiveFilter}
-              />
+              <View style={{ backgroundColor: Colors.surface }}>
+                <FilterBar
+                  filters={statusFilters}
+                  active={activeFilter}
+                  onSelect={setActiveFilter}
+                />
+              </View>
             );
           }
           if (item.renderType === "search") {
@@ -377,7 +389,6 @@ export default function TasksScreen() {
             );
           }
           return (
-
             <SwipeableTaskItem
               task={item}
               onToggleComplete={toggleTaskDone}
@@ -401,11 +412,7 @@ export default function TasksScreen() {
           paddingHorizontal: Spacing.large,
           paddingTop: Spacing.base,
         }}
-        ListFooterComponent={
-          <View
-            style={{ height: FAB_SIZE + insets.bottom + Spacing.large }}
-          />
-        }
+        ListFooterComponent={<View style={{ height: fabOffset + Spacing.large }} />}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
         removeClippedSubviews={false}
@@ -416,7 +423,14 @@ export default function TasksScreen() {
         accessibilityRole="list"
       />
 
-      <AddTaskButton onPress={onAddTask} />
+      <TouchableOpacity
+        style={[styles.fab, { bottom: fabOffset }]}
+        onPress={onAddTask}
+        accessibilityRole="button"
+        accessibilityLabel="Añadir tarea"
+      >
+        <FontAwesome name="plus" size={20} color={Colors.onAccent} />
+      </TouchableOpacity>
 
       <Modal
         visible={filtersVisible}

--- a/src/screens/TasksScreen.styles.js
+++ b/src/screens/TasksScreen.styles.js
@@ -5,7 +5,8 @@
 // Autor: Codex - Fecha: 2025-08-13
 
 import { StyleSheet } from "react-native";
-import { Colors, Spacing, Radii } from "../theme";
+import { Colors, Spacing, Radii, Elevation } from "../theme";
+import { FAB_SIZE } from "../components/AddTaskButton/AddTaskButton.styles";
 
 export default StyleSheet.create({
   container: {
@@ -24,5 +25,18 @@ export default StyleSheet.create({
     borderRadius: Radii.md,
     padding: Spacing.base,
     maxHeight: "90%",
+  },
+  fab: {
+    position: "absolute",
+    right: Spacing.large,
+    width: FAB_SIZE,
+    height: FAB_SIZE,
+    borderRadius: FAB_SIZE / 2,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: Colors.accent,
+    zIndex: 60,
+    ...Elevation.card,
+    elevation: 8,
   },
 });


### PR DESCRIPTION
## Summary
- Restore FilterBar component with corrected flex syntax and sticky elevation
- Revert to SwipeableTaskItem and split chips into element/type/priority and label rows
- Offset FAB by tab bar and safe area while padding list like Home

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d04234d188327a3a17d2d718ddcc4