### PR TITLE
style: unify TasksScreen list spacing

### DIFF
--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -402,16 +402,12 @@ export default function TasksScreen() {
           );
         }}
         ListHeaderComponent={
-          <View style={{ marginVertical: Spacing.small }}>
+          <View style={{ marginBottom: Spacing.large }}>
             <StatsHeader />
           </View>
         }
         stickyHeaderIndices={[1]}
-
-        contentContainerStyle={{
-          paddingHorizontal: Spacing.large,
-          paddingTop: Spacing.base,
-        }}
+        contentContainerStyle={styles.content}
         ListFooterComponent={<View style={{ height: fabOffset + Spacing.large }} />}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}

--- a/src/screens/TasksScreen.styles.js
+++ b/src/screens/TasksScreen.styles.js
@@ -13,6 +13,12 @@ export default StyleSheet.create({
     flex: 1,
     backgroundColor: Colors.background,
   },
+  content: {
+    paddingHorizontal: Spacing.base,
+    paddingTop: Spacing.base,
+    gap: Spacing.large,
+    paddingBottom: FAB_SIZE + Spacing.large * 2,
+  },
   filterModalBackground: {
     flex: 1,
     backgroundColor: Colors.overlay,


### PR DESCRIPTION
## Summary
- add content style in TasksScreen.styles to mirror HomeScreen spacing
- use styles.content for FlatList and tweak StatsHeader margin

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d24ef3d988327843b2d97c0a69ac2