### PR TITLE
refactor: align TaskCard padding

### DIFF
--- a/src/components/TaskCard/TaskCardStyles.js
+++ b/src/components/TaskCard/TaskCardStyles.js
@@ -51,10 +51,9 @@ export default StyleSheet.create({
     width: "100%",
     backgroundColor: Colors.surfaceElevated,
     borderRadius: Radii.lg,
-    paddingRight: Spacing.base,
     paddingVertical: Spacing.base,
-    paddingLeft: Spacing.large,
-    marginVertical: Spacing.small,
+    paddingHorizontal: Spacing.large,
+    marginBottom: Spacing.large,
     ...Elevation.card,
   },
   accentBar: {


### PR DESCRIPTION
## Summary
- replace TaskCard horizontal padding with single paddingHorizontal
- adjust TaskCard margin to match Home spacing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d24f05cc8832788038bf70f99cbd8