### PR TITLE
[MB] TasksScreen — sticky filter block and UI refinements

### DIFF
--- a/src/components/FilterBar/FiltersHeader.js
+++ b/src/components/FilterBar/FiltersHeader.js
@@ -1,8 +1,9 @@
+// [MB] FiltersHeader — bloque de tabs y buscador
 // [MB] Módulo: Tasks / Sección: Encabezado de filtros
 // Afecta: TasksScreen (bloque sticky de filtros)
 // Propósito: Agrupar tabs de estado y barra de búsqueda
 // Puntos de edición futura: animaciones y estados vacíos
-// Autor: Codex - Fecha: 2025-02-14
+// Autor: Codex - Fecha: 2025-08-14
 
 import React from "react";
 import { View } from "react-native";
@@ -19,7 +20,7 @@ export default function FiltersHeader({
   onToggleAdvanced,
 }) {
   return (
-    <View style={styles.container}>
+    <View style={styles.container} accessibilityRole="header">
       <TaskFilterBar filters={statusFilters} active={activeFilter} onSelect={onSelectFilter} />
       <SearchBar
         value={searchQuery}

--- a/src/components/FilterBar/FiltersHeader.styles.js
+++ b/src/components/FilterBar/FiltersHeader.styles.js
@@ -1,8 +1,9 @@
+// [MB] FiltersHeader.styles — bloque de filtros sticky
 // [MB] Módulo: Tasks / Sección: Encabezado de filtros
 // Afecta: FiltersHeader
 // Propósito: Espaciado y fondo del bloque sticky
 // Puntos de edición futura: elevación y animaciones
-// Autor: Codex - Fecha: 2025-02-14
+// Autor: Codex - Fecha: 2025-08-14
 
 import { StyleSheet } from "react-native";
 import { Colors, Spacing } from "../../theme";
@@ -10,8 +11,7 @@ import { Colors, Spacing } from "../../theme";
 export default StyleSheet.create({
   container: {
     backgroundColor: Colors.background,
-    paddingHorizontal: Spacing.base,
-    paddingBottom: Spacing.small,
+    paddingVertical: Spacing.small,
     gap: Spacing.small,
   },
 });

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -1,8 +1,9 @@
+// [MB] SearchBar — buscador cómodo con botón de filtros
 // [MB] Módulo: Tasks / Sección: Barra de búsqueda
 // Afecta: SearchBar
 // Propósito: Campo de búsqueda con acceso a filtros avanzados
 // Puntos de edición futura: estados de focus y validaciones
-// Autor: Codex - Fecha: 2025-02-14
+// Autor: Codex - Fecha: 2025-08-14
 
 import React from "react";
 import { View, TextInput, TouchableOpacity } from "react-native";
@@ -13,7 +14,7 @@ import { Colors } from "../../theme";
 export default function SearchBar({ value, onChange, onToggleAdvanced }) {
   return (
     <View style={styles.container}>
-      <View style={styles.inner}>
+      <View style={styles.searchBox}>
         <FontAwesome5 name="search" size={16} color={Colors.textMuted} />
         <TextInput
           style={styles.input}
@@ -21,9 +22,16 @@ export default function SearchBar({ value, onChange, onToggleAdvanced }) {
           placeholderTextColor={Colors.textMuted}
           value={value}
           onChangeText={onChange}
+          accessibilityRole="search"
+          accessibilityLabel="Buscar tareas"
         />
       </View>
-      <TouchableOpacity onPress={onToggleAdvanced} style={styles.button}>
+      <TouchableOpacity
+        onPress={onToggleAdvanced}
+        style={styles.filterButton}
+        accessibilityRole="button"
+        accessibilityLabel="Abrir filtros"
+      >
         <FontAwesome5 name="sliders-h" size={17} color={Colors.textMuted} />
       </TouchableOpacity>
     </View>

--- a/src/components/SearchBar/SearchBar.styles.js
+++ b/src/components/SearchBar/SearchBar.styles.js
@@ -1,8 +1,9 @@
+// [MB] SearchBar.styles — ajusta buscador full-width
 // [MB] Módulo: Tasks / Sección: Barra de búsqueda
 // Afecta: SearchBar
 // Propósito: Estilo alineado al tema
 // Puntos de edición futura: focos y estados deshabilitados
-// Autor: Codex - Fecha: 2025-02-14
+// Autor: Codex - Fecha: 2025-08-14
 
 import { StyleSheet } from "react-native";
 import { Colors, Spacing, Radii } from "../../theme";
@@ -11,19 +12,20 @@ export default StyleSheet.create({
   container: {
     flexDirection: "row",
     alignItems: "center",
-    backgroundColor: Colors.surface,
-    paddingHorizontal: Spacing.small + Spacing.tiny,
-    paddingVertical: Spacing.small,
-    borderRadius: Radii.lg,
-    justifyContent: "space-between",
-    minHeight: Spacing.xlarge + Spacing.tiny,
-    borderWidth: 1,
-    borderColor: Colors.separator,
+    width: "100%",
+    gap: Spacing.small,
   },
-  inner: {
+  searchBox: {
     flexDirection: "row",
     alignItems: "center",
     flex: 1,
+    backgroundColor: Colors.surface,
+    paddingHorizontal: Spacing.base - Spacing.tiny,
+    paddingVertical: Spacing.small,
+    borderRadius: Radii.lg,
+    borderWidth: 1,
+    borderColor: Colors.separator,
+    minHeight: Spacing.large + Spacing.base + Spacing.tiny,
     gap: Spacing.small,
   },
   input: {
@@ -32,9 +34,14 @@ export default StyleSheet.create({
     fontSize: 14,
     padding: 0,
   },
-  button: {
-    // Botón para filtros avanzados
-    marginLeft: Spacing.small,
-    opacity: 0.9,
+  filterButton: {
+    width: Spacing.base * 2,
+    height: Spacing.base * 2,
+    borderRadius: Radii.lg,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: Colors.surface,
+    borderWidth: 1,
+    borderColor: Colors.separator,
   },
 });

--- a/src/components/TaskCard/TaskCard.js
+++ b/src/components/TaskCard/TaskCard.js
@@ -1,8 +1,9 @@
+// [MB] TaskCard — tarjeta con borde por dificultad
 // [MB] Módulo: Tasks / Sección: Tarjeta de tarea
 // Afecta: TasksScreen (interacción de completar y eliminar tareas)
 // Propósito: Item de tarea deslizable con acciones y recompensas
 // Puntos de edición futura: animaciones y estilos en TaskCard
-// Autor: Codex - Fecha: 2025-02-14
+// Autor: Codex - Fecha: 2025-08-14
 
 import React, { useRef, useState } from "react";
 import {

--- a/src/components/TaskCard/TaskCardStyles.js
+++ b/src/components/TaskCard/TaskCardStyles.js
@@ -1,8 +1,9 @@
+// [MB] TaskCardStyles — tarjeta con borde por dificultad
 // [MB] Módulo: Tasks / Sección: Tarjeta de tarea
 // Afecta: TaskCard
 // Propósito: estilos de tarjeta y chips
 // Puntos de edición futura: animaciones y badges
-// Autor: Codex - Fecha: 2025-02-14
+// Autor: Codex - Fecha: 2025-08-14
 
 import { StyleSheet } from "react-native";
 import { Colors, Spacing, Radii, Elevation, Typography } from "../../theme";
@@ -47,7 +48,6 @@ export default StyleSheet.create({
     borderRadius: Radii.lg,
     paddingVertical: Spacing.small + Spacing.tiny,
     paddingHorizontal: Spacing.small + Spacing.tiny,
-    marginBottom: Spacing.small,
     borderLeftWidth: 3,
     flexDirection: "column",
     gap: Spacing.small,
@@ -135,10 +135,10 @@ export default StyleSheet.create({
     flexDirection: "row",
     flexWrap: "wrap",
     alignItems: "center",
-    gap: Spacing.tiny,
+    gap: Spacing.small,
   },
   labelRow: {
-    marginTop: Spacing.tiny,
+    marginTop: Spacing.small,
   },
   elementChip: {
     width: Spacing.base * 2,

--- a/src/components/TaskFilterBar/TaskFilterBar.js
+++ b/src/components/TaskFilterBar/TaskFilterBar.js
@@ -1,8 +1,9 @@
+// [MB] TaskFilterBar — tabs de estado segmentadas
 // [MB] Módulo: Tasks / Sección: Barra de filtros
 // Afecta: TaskFilterBar (tabs principales)
 // Propósito: Tabs accesibles alineadas al tema
 // Puntos de edición futura: animaciones y desplazamiento
-// Autor: Codex - Fecha: 2025-02-14
+// Autor: Codex - Fecha: 2025-08-14
 
 import React from "react";
 import { View, Pressable, Text } from "react-native";

--- a/src/components/TaskFilterBar/TaskFilterBar.styles.js
+++ b/src/components/TaskFilterBar/TaskFilterBar.styles.js
@@ -1,8 +1,9 @@
+// [MB] TaskFilterBar.styles — tabs segmentadas
 // [MB] Módulo: Tasks / Sección: Barra de filtros
 // Afecta: TaskFilterBar (tabs principales)
 // Propósito: Estilos de control segmentado para estado de tareas
 // Puntos de edición futura: animaciones y accesibilidad
-// Autor: Codex - Fecha: 2025-02-14
+// Autor: Codex - Fecha: 2025-08-14
 
 import { StyleSheet } from "react-native";
 import { Colors, Spacing, Radii } from "../../theme";

--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -1,8 +1,9 @@
+// [MB] TasksScreen — filtros sticky y FAB en gradiente
 // [MB] Módulo: Tasks / Sección: Pantalla de tareas
 // Afecta: TasksScreen (listado y gestión de tareas)
 // Propósito: Listar, filtrar y persistir tareas con recompensas seguras
 // Puntos de edición futura: manejo remoto y estilos de filtros
-// Autor: Codex - Fecha: 2025-02-14
+// Autor: Codex - Fecha: 2025-08-14
 
 import React, { useState, useEffect, useMemo } from "react";
 import {
@@ -24,7 +25,7 @@ import TaskFilters from "../components/TaskFilters";
 import TaskCard from "../components/TaskCard/TaskCard";
 import FiltersHeader from "../components/FilterBar/FiltersHeader";
 import styles from "./TasksScreen.styles";
-import { Colors, Spacing } from "../theme";
+import { Colors, Spacing, Gradients } from "../theme";
 import CreateTaskModal from "../components/CreateTaskModal/CreateTaskModal";
 import { useAppDispatch } from "../state/AppContext";
 import { XP_REWARD_BY_PRIORITY } from "../constants/rewards";
@@ -344,7 +345,10 @@ export default function TasksScreen() {
   ]);
 
   // ——— 5) Render ———
-  const listData = useMemo(() => filteredTasks, [filteredTasks]);
+  const listData = useMemo(
+    () => [{ type: "filters", key: "filters" }, ...filteredTasks],
+    [filteredTasks]
+  );
 
   return (
     <SafeAreaView style={[styles.container, { paddingTop: insets.top }]}>
@@ -356,24 +360,9 @@ export default function TasksScreen() {
 
       <FlatList
         data={listData}
-        keyExtractor={(item) => item.id}
-        renderItem={({ item }) => (
-          <TaskCard
-            task={item}
-            onToggleComplete={toggleTaskDone}
-            onSoftDeleteTask={onSoftDeleteTask}
-            onRestoreTask={onRestoreTask}
-            onPermanentDeleteTask={onPermanentDeleteTask}
-            onEditTask={onEditTask}
-            onToggleSubtask={onToggleSubtask}
-            activeFilter={activeFilter}
-          />
-        )}
-        ListHeaderComponent={() => (
-          <>
-            <View style={{ marginBottom: Spacing.small }}>
-              <StatsHeader />
-            </View>
+        keyExtractor={(item) => item.id || item.key}
+        renderItem={({ item }) =>
+          item.type === "filters" ? (
             <FiltersHeader
               statusFilters={statusFilters}
               activeFilter={activeFilter}
@@ -382,11 +371,29 @@ export default function TasksScreen() {
               onChangeSearch={setSearchQuery}
               onToggleAdvanced={() => setFiltersVisible(true)}
             />
-          </>
+          ) : (
+            <TaskCard
+              task={item}
+              onToggleComplete={toggleTaskDone}
+              onSoftDeleteTask={onSoftDeleteTask}
+              onRestoreTask={onRestoreTask}
+              onPermanentDeleteTask={onPermanentDeleteTask}
+              onEditTask={onEditTask}
+              onToggleSubtask={onToggleSubtask}
+              activeFilter={activeFilter}
+            />
+          )
+        }
+        ListHeaderComponent={() => (
+          <View style={{ marginBottom: Spacing.small }}>
+            <StatsHeader />
+          </View>
         )}
         stickyHeaderIndices={[1]}
-        contentContainerStyle={styles.content}
-        ListFooterComponent={<View style={{ height: fabOffset + Spacing.large }} />}
+        contentContainerStyle={[styles.content, { paddingBottom: fabOffset }]}
+        ItemSeparatorComponent={() => (
+          <View style={{ height: Spacing.small + Spacing.tiny }} />
+        )}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
         removeClippedSubviews={false}
@@ -404,9 +411,9 @@ export default function TasksScreen() {
         accessibilityLabel="Añadir tarea"
       >
         <LinearGradient
-          colors={[Colors.secondary, Colors.primary]}
+          colors={Gradients.xp}
           start={{ x: 0, y: 0 }}
-          end={{ x: 1, y: 1 }}
+          end={{ x: 1, y: 0 }}
           style={styles.fabGradient}
         >
           <FontAwesome name="plus" size={20} color={Colors.onAccent} />

--- a/src/screens/TasksScreen.styles.js
+++ b/src/screens/TasksScreen.styles.js
@@ -1,8 +1,9 @@
+// [MB] TasksScreen.styles — ajustes de layout y FAB
 // [MB] Módulo: Tasks / Sección: Pantalla de tareas
 // Afecta: TasksScreen
 // Propósito: Estilos base alineados al home
 // Puntos de edición futura: ajustes de layout y modales
-// Autor: Codex - Fecha: 2025-02-14
+// Autor: Codex - Fecha: 2025-08-14
 
 import { StyleSheet } from "react-native";
 import { Colors, Spacing, Radii, Elevation } from "../theme";
@@ -38,8 +39,7 @@ export default StyleSheet.create({
     borderRadius: FAB_SIZE / 2,
     overflow: "hidden",
     zIndex: 60,
-    ...Elevation.card,
-    elevation: 8,
+    ...Elevation.raised,
   },
   fabGradient: {
     flex: 1,


### PR DESCRIPTION
## Summary
- make filters block sticky via FlatList item and adjust spacing
- restyle search bar, tabs, and task cards using theme tokens
- add XP gradient FAB and ensure accessible controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d64d826d083279ff4678c5c5c600e