### PR TITLE
feat: alinear acciones y recompensas en TaskCard

### DIFF
--- a/src/components/TaskCard/TaskCard.js
+++ b/src/components/TaskCard/TaskCard.js
@@ -1,4 +1,4 @@
-// [MB] TaskCard — chips ajustados y columna derecha
+// [MB] TaskCard — acciones reordenadas, contador y recompensas
 // [MB] Módulo: Tasks / Sección: Tarjeta de tarea
 // Afecta: TasksScreen (interacción de completar y eliminar tareas)
 // Propósito: Item de tarea deslizable con acciones y recompensas
@@ -254,19 +254,24 @@ export default function TaskCard({
           </View>
         </TouchableOpacity>
 
-        {task.subtasks?.length > 0 && (
+        {totalSubtasks > 0 && (
           <>
-            <TouchableOpacity
-              style={styles.subtaskToggle}
-              onPress={() => setShowSubtasks(!showSubtasks)}
-            >
-              <FontAwesome5
-                name={showSubtasks ? "chevron-up" : "chevron-down"}
-                size={12}
-                color={Colors.textMuted}
-              />
-              <Text style={styles.subtaskToggleText}>Subtareas</Text>
-            </TouchableOpacity>
+            <View style={styles.subtaskHeader}>
+              <TouchableOpacity
+                style={styles.subtaskToggle}
+                onPress={() => setShowSubtasks(!showSubtasks)}
+              >
+                <FontAwesome5
+                  name={showSubtasks ? "chevron-up" : "chevron-down"}
+                  size={12}
+                  color={Colors.textMuted}
+                />
+                <Text style={styles.subtaskToggleText}>Subtareas</Text>
+              </TouchableOpacity>
+              <View style={styles.subtaskCountChip}>
+                <Text style={styles.subtaskCountText}>{`${completedSubtasks}/${totalSubtasks}`}</Text>
+              </View>
+            </View>
             {showSubtasks && (
               <View style={styles.subtaskList}>
                 {task.subtasks.length > 5 ? (
@@ -397,53 +402,57 @@ export default function TaskCard({
             </Text>
           </View>
         </View>
-        {task.tags?.length > 0 && (
-          <View style={[styles.metaRow, styles.labelRow]}>
-            {task.tags.map((tag) => (
+        <View style={[styles.metaRow, styles.labelRow]}>
+          {task.tags?.length > 0 &&
+            task.tags.map((tag) => (
               <View key={tag} style={[styles.chip, styles.tagChip]}>
                 <Text style={styles.chipText}>{tag}</Text>
               </View>
             ))}
-          </View>
-        )}
+          <Text
+            style={[
+              styles.rewardInlineText,
+              task.tags?.length > 0 && styles.rewardInlineSpacing,
+            ]}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+          >{`+${xp} XP · +${mana} ⚡`}</Text>
+        </View>
         </View>
         <View style={styles.rightColumn}>
-          <View style={styles.rewardBox}>
-            <Text style={styles.rewardText}>{`+${xp} XP`}</Text>
-            <Text style={styles.rewardText}>{`+${mana} ⚡`}</Text>
+          <View style={styles.actionRow}>
+            <TouchableOpacity
+              style={[styles.actionChip, styles.completeButton]}
+              onPress={handleQuickComplete}
+              accessibilityRole="button"
+              accessibilityLabel="Completar tarea"
+              hitSlop={HIT_SLOP}
+            >
+              <FontAwesome5 name="check" size={14} color={Colors.background} />
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.actionChip}
+              onPress={() => onEditTask(task)}
+              accessibilityRole="button"
+              accessibilityLabel="Editar tarea"
+              hitSlop={HIT_SLOP}
+            >
+              <FontAwesome5 name="pen" size={14} color={Colors.text} />
+            </TouchableOpacity>
           </View>
-          {totalSubtasks > 0 && (
-            <Text style={styles.progressText}>{`${completedSubtasks}/${totalSubtasks}`}</Text>
-          )}
           <TouchableOpacity
-            style={styles.iconButton}
+            style={styles.reminderButton}
             onPress={() => onEditTask(task)}
             accessibilityRole="button"
-            accessibilityLabel={`Recordatorios ${reminderCount}`}
+            accessibilityLabel="Recordatorios de tarea"
             hitSlop={HIT_SLOP}
           >
             <FontAwesome5 name="bell" size={14} color={Colors.text} />
             {reminderCount > 0 && (
-              <Text style={styles.iconBadge}>{reminderCount}</Text>
+              <View style={styles.badge}>
+                <Text style={styles.badgeText}>{reminderCount}</Text>
+              </View>
             )}
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={styles.iconButton}
-            onPress={() => onEditTask(task)}
-            accessibilityRole="button"
-            accessibilityLabel="Editar tarea"
-            hitSlop={HIT_SLOP}
-          >
-            <FontAwesome5 name="pen" size={14} color={Colors.text} />
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={styles.iconButton}
-            onPress={handleQuickComplete}
-            accessibilityRole="button"
-            accessibilityLabel={task.completed ? "Marcar incompleta" : "Completar tarea"}
-            hitSlop={HIT_SLOP}
-          >
-            <FontAwesome5 name="check" size={14} color={Colors.text} />
           </TouchableOpacity>
         </View>
       </Animated.View>

--- a/src/components/TaskCard/TaskCardStyles.js
+++ b/src/components/TaskCard/TaskCardStyles.js
@@ -1,4 +1,4 @@
-// [MB] TaskCardStyles — chips más bajos y columna derecha
+// [MB] TaskCardStyles — acciones y subtareas reordenadas
 // [MB] Módulo: Tasks / Sección: Tarjeta de tarea
 // Afecta: TaskCard
 // Propósito: estilos de tarjeta y chips
@@ -61,31 +61,53 @@ export default StyleSheet.create({
     gap: Spacing.small,
   },
   rightColumn: {
-    width: Spacing.base * 5 + Spacing.small,
+    width: Spacing.base * 4 + Spacing.small,
     alignItems: "flex-end",
     gap: Spacing.small,
     paddingLeft: Spacing.small,
   },
-  rewardBox: {
-    alignItems: "flex-end",
-  },
-  rewardText: {
-    ...Typography.caption,
-    color: Colors.textMuted,
-  },
-  progressText: {
-    ...Typography.caption,
-    color: Colors.textMuted,
-  },
-  iconButton: {
+  actionRow: {
     flexDirection: "row",
     alignItems: "center",
-    alignSelf: "flex-end",
-    gap: Spacing.tiny,
+    gap: Spacing.small,
   },
-  iconBadge: {
+  actionChip: {
+    width: Spacing.xlarge,
+    height: Spacing.xlarge,
+    borderRadius: Radii.pill,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: Colors.surfaceElevated,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  completeButton: {
+    backgroundColor: Colors.secondary,
+    borderWidth: 0,
+  },
+  reminderButton: {
+    position: "relative",
+    padding: Spacing.tiny,
+    alignItems: "center",
+    justifyContent: "center",
+    alignSelf: "flex-end",
+  },
+  badge: {
+    position: "absolute",
+    top: -2,
+    right: -2,
+    minWidth: Spacing.base,
+    height: Spacing.base,
+    borderRadius: Radii.pill,
+    backgroundColor: Colors.accent,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  badgeText: {
     ...Typography.caption,
-    color: Colors.text,
+    fontSize: Typography.caption.fontSize - 2,
+    color: Colors.onAccent,
+    lineHeight: Typography.caption.fontSize,
   },
   contentRow: {
     flexDirection: "row",
@@ -109,18 +131,34 @@ export default StyleSheet.create({
     color: Colors.textMuted,
     textDecorationLine: "line-through",
   },
+  subtaskHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.small,
+    marginTop: Spacing.tiny,
+    marginBottom: Spacing.tiny,
+  },
   subtaskToggle: {
     flexDirection: "row",
     alignItems: "center",
-    marginTop: Spacing.tiny,
-    marginBottom: Spacing.tiny,
-    paddingHorizontal: Spacing.tiny,
   },
   subtaskToggleText: {
-    color: Colors.textMuted,
+    color: Colors.secondary,
     marginLeft: Spacing.small,
     fontSize: 12,
-    marginBottom: Spacing.tiny,
+  },
+  subtaskCountChip: {
+    minHeight: Spacing.base + Spacing.small + Spacing.tiny,
+    paddingHorizontal: Spacing.small,
+    paddingVertical: Spacing.tiny,
+    borderRadius: Radii.pill,
+    backgroundColor: Colors.secondary,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  subtaskCountText: {
+    ...Typography.caption,
+    color: Colors.background,
   },
   subtaskList: {
     marginTop: 1,
@@ -203,6 +241,14 @@ export default StyleSheet.create({
     borderColor: Colors.border,
     minHeight: Spacing.base + Spacing.small + Spacing.tiny,
     paddingHorizontal: Spacing.small,
+  },
+  rewardInlineText: {
+    ...Typography.caption,
+    color: Colors.textMuted,
+    flexShrink: 1,
+  },
+  rewardInlineSpacing: {
+    marginLeft: Spacing.small,
   },
   priorityChipText: {
     fontWeight: "500",


### PR DESCRIPTION
## Summary
- reordena acciones superiores con botón de completar y editar
- mueve contador de subtareas al encabezado y muestra recompensas junto a etiquetas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d6dad9d8083279f5a90481df0c326