### PR TITLE
refactor: simplify TaskCard actions and rewards

### DIFF
--- a/src/components/TaskCard/TaskCard.js
+++ b/src/components/TaskCard/TaskCard.js
@@ -1,4 +1,4 @@
-// [MB] TaskCard — acciones reordenadas, contador y recompensas
+// [MB] TaskCard — limpieza acciones, recompensas y subtareas.
 // [MB] Módulo: Tasks / Sección: Tarjeta de tarea
 // Afecta: TasksScreen (interacción de completar y eliminar tareas)
 // Propósito: Item de tarea deslizable con acciones y recompensas
@@ -150,12 +150,6 @@ export default function TaskCard({
   };
   const handlePressOut = () => {
     Animated.spring(scale, { toValue: 1, useNativeDriver: true }).start();
-  };
-  const handleQuickComplete = () => {
-    if (!task.completed && onTaskCompleted) {
-      onTaskCompleted(task);
-    }
-    onToggleComplete(task.id);
   };
   // Información del elemento (icono y color)
   // se usa una función para evitar lógica compleja en el render
@@ -368,7 +362,7 @@ export default function TaskCard({
           </>
         )}
 
-        {/* ——— Chips de metadatos ——— */}
+        {/* ——— Chips de metadatos y recompensas ——— */}
         <View style={styles.metaRow}>
           <View
             style={[styles.elementChip, { backgroundColor: elementInfo.color }]}
@@ -401,53 +395,47 @@ export default function TaskCard({
               {getPriorityLabel(task.priority)}
             </Text>
           </View>
-        </View>
-        <View style={[styles.metaRow, styles.labelRow]}>
-          {task.tags?.length > 0 &&
-            task.tags.map((tag) => (
-              <View key={tag} style={[styles.chip, styles.tagChip]}>
-                <Text style={styles.chipText}>{tag}</Text>
-              </View>
-            ))}
           <Text
             style={[
               styles.rewardInlineText,
-              task.tags?.length > 0 && styles.rewardInlineSpacing,
+              { color: getPriorityColor(task.priority) },
             ]}
             numberOfLines={1}
             ellipsizeMode="tail"
           >{`+${xp} XP · +${mana} ⚡`}</Text>
         </View>
+        {task.tags?.length > 0 && (
+          <View style={[styles.metaRow, styles.labelRow]}>
+            {task.tags.map((tag) => (
+              <View key={tag} style={[styles.chip, styles.tagChip]}>
+                <Text style={styles.chipText}>{tag}</Text>
+              </View>
+            ))}
+          </View>
+        )}
         </View>
         <View style={styles.rightColumn}>
-          <View style={styles.actionRow}>
-            <TouchableOpacity
-              style={[styles.actionChip, styles.completeButton]}
-              onPress={handleQuickComplete}
-              accessibilityRole="button"
-              accessibilityLabel="Completar tarea"
-              hitSlop={HIT_SLOP}
-            >
-              <FontAwesome5 name="check" size={14} color={Colors.background} />
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={styles.actionChip}
-              onPress={() => onEditTask(task)}
-              accessibilityRole="button"
-              accessibilityLabel="Editar tarea"
-              hitSlop={HIT_SLOP}
-            >
-              <FontAwesome5 name="pen" size={14} color={Colors.text} />
-            </TouchableOpacity>
-          </View>
+          <TouchableOpacity
+            style={styles.editButton}
+            onPress={() => onEditTask(task)}
+            accessibilityRole="button"
+            accessibilityLabel="Editar tarea"
+            hitSlop={HIT_SLOP}
+          >
+            <FontAwesome5 name="pen" size={14} color={Colors.text} />
+          </TouchableOpacity>
           <TouchableOpacity
             style={styles.reminderButton}
             onPress={() => onEditTask(task)}
             accessibilityRole="button"
-            accessibilityLabel="Recordatorios de tarea"
+            accessibilityLabel={`Recordatorios de tarea (${reminderCount})`}
             hitSlop={HIT_SLOP}
           >
-            <FontAwesome5 name="bell" size={14} color={Colors.text} />
+            <FontAwesome5
+              name="bell"
+              size={14}
+              color={reminderCount > 0 ? Colors.text : Colors.textMuted}
+            />
             {reminderCount > 0 && (
               <View style={styles.badge}>
                 <Text style={styles.badgeText}>{reminderCount}</Text>

--- a/src/components/TaskCard/TaskCardStyles.js
+++ b/src/components/TaskCard/TaskCardStyles.js
@@ -1,4 +1,4 @@
-// [MB] TaskCardStyles — acciones y subtareas reordenadas
+// [MB] TaskCardStyles — limpieza acciones, recompensas y subtareas.
 // [MB] Módulo: Tasks / Sección: Tarjeta de tarea
 // Afecta: TaskCard
 // Propósito: estilos de tarjeta y chips
@@ -66,14 +66,9 @@ export default StyleSheet.create({
     gap: Spacing.small,
     paddingLeft: Spacing.small,
   },
-  actionRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: Spacing.small,
-  },
-  actionChip: {
-    width: Spacing.xlarge,
-    height: Spacing.xlarge,
+  editButton: {
+    width: Spacing.large,
+    height: Spacing.large,
     borderRadius: Radii.pill,
     justifyContent: "center",
     alignItems: "center",
@@ -81,13 +76,10 @@ export default StyleSheet.create({
     borderWidth: 1,
     borderColor: Colors.border,
   },
-  completeButton: {
-    backgroundColor: Colors.secondary,
-    borderWidth: 0,
-  },
   reminderButton: {
     position: "relative",
-    padding: Spacing.tiny,
+    width: Spacing.large,
+    height: Spacing.large,
     alignItems: "center",
     justifyContent: "center",
     alignSelf: "flex-end",
@@ -148,9 +140,8 @@ export default StyleSheet.create({
     fontSize: 12,
   },
   subtaskCountChip: {
-    minHeight: Spacing.base + Spacing.small + Spacing.tiny,
+    height: Spacing.base + Spacing.tiny,
     paddingHorizontal: Spacing.small,
-    paddingVertical: Spacing.tiny,
     borderRadius: Radii.pill,
     backgroundColor: Colors.secondary,
     justifyContent: "center",
@@ -158,6 +149,8 @@ export default StyleSheet.create({
   },
   subtaskCountText: {
     ...Typography.caption,
+    fontSize: Typography.caption.fontSize - 2,
+    lineHeight: Typography.caption.fontSize,
     color: Colors.background,
   },
   subtaskList: {
@@ -244,11 +237,11 @@ export default StyleSheet.create({
   },
   rewardInlineText: {
     ...Typography.caption,
-    color: Colors.textMuted,
     flexShrink: 1,
-  },
-  rewardInlineSpacing: {
-    marginLeft: Spacing.small,
+    marginLeft: "auto",
+    textShadowColor: "rgba(0,0,0,0.15)",
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 1,
   },
   priorityChipText: {
     fontWeight: "500",


### PR DESCRIPTION
## Summary
- remove quick-complete check from TaskCard
- align rewards with metadata chips and add reminder bell
- refine subtask count chip styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d716fc8ac8327b3bf53bff6a66b2e