### PR TITLE
feat: header chips with rewards screen

### DIFF
--- a/App.js
+++ b/App.js
@@ -18,6 +18,7 @@ import ProfileScreen from "./src/screens/ProfileScreen";
 import InventoryScreen from "./src/screens/InventoryScreen";
 import NewsInboxScreen from "./src/screens/NewsInboxScreen";
 import ShopScreen from "./src/screens/ShopScreen";
+import RewardsScreen from "./src/screens/RewardsScreen";
 import { AppProvider } from "./src/state/AppContext";
 
 const Tab = createBottomTabNavigator();
@@ -59,6 +60,11 @@ export default function App() {
           <RootStack.Screen
             name="ShopScreen"
             component={ShopScreen}
+            options={{ headerShown: false }}
+          />
+          <RootStack.Screen
+            name="Rewards"
+            component={RewardsScreen}
             options={{ headerShown: false }}
           />
         </RootStack.Navigator>

--- a/src/components/home/HomeHeader.styles.js
+++ b/src/components/home/HomeHeader.styles.js
@@ -1,8 +1,8 @@
 // [MB] Módulo: Home / Sección: HomeHeader
 // Afecta: HomeHeader
-// Propósito: Estilos para encabezado principal en dos filas
-// Puntos de edición futura: ajustar layout responsivo
-// Autor: Codex - Fecha: 2025-02-15
+// Propósito: Estilos para top bar, chips y popovers del encabezado
+// Puntos de edición futura: ajustar tamaños de chip y responsividad
+// Autor: Codex - Fecha: 2025-08-30
 
 import { StyleSheet } from "react-native";
 import { Colors, Spacing, Radii, Typography, Elevation } from "../../theme";
@@ -13,37 +13,20 @@ export default StyleSheet.create({
     paddingHorizontal: Spacing.base,
     paddingTop: Spacing.base,
     paddingBottom: Spacing.small,
-    gap: Spacing.small,
     ...Elevation.raised,
   },
-  row1: {
+  topBar: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
   },
-  title: {
-    ...Typography.h1,
-    color: Colors.text,
-  },
-  row1Right: {
+  topBarRight: {
     flexDirection: "row",
     alignItems: "center",
-    flexWrap: "wrap",
     gap: Spacing.tiny,
   },
-  pill: {
-    flexDirection: "row",
-    alignItems: "center",
-    backgroundColor: Colors.surface,
-    borderRadius: Radii.md,
-    paddingHorizontal: Spacing.small,
-    height: 28,
-  },
-  pillIcon: {
-    marginRight: Spacing.tiny,
-  },
-  pillText: {
-    ...Typography.caption,
+  title: {
+    ...Typography.title,
     color: Colors.text,
   },
   iconButton: {
@@ -55,10 +38,62 @@ export default StyleSheet.create({
     borderRadius: Radii.md,
     backgroundColor: Colors.surface,
   },
-  row2: {
+  chipBlock: {
+    marginTop: Spacing.small,
+  },
+  chipRow: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
+    gap: Spacing.small,
+  },
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: Colors.surface,
+    borderRadius: Radii.lg,
+    paddingHorizontal: Spacing.small,
+    height: 28,
+  },
+  chipIcon: {
+    marginRight: Spacing.tiny,
+  },
+  chipText: {
+    ...Typography.caption,
+    color: Colors.text,
+  },
+  popoverRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginTop: Spacing.small,
+  },
+  popoverSlot: {
+    flex: 1,
+    alignItems: "center",
+  },
+  popover: {
+    backgroundColor: Colors.surfaceElevated,
+    borderColor: Colors.border,
+    borderWidth: 1,
+    borderRadius: Radii.lg,
+    padding: Spacing.base,
+    ...Elevation.raised,
+  },
+  popoverTitle: {
+    ...Typography.body,
+    fontWeight: "600",
+    color: Colors.text,
+    marginBottom: Spacing.tiny,
+  },
+  popoverDesc: {
+    ...Typography.caption,
+    color: Colors.textMuted,
+  },
+  levelRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginTop: Spacing.small,
   },
   levelContainer: {
     flex: 1,
@@ -79,22 +114,10 @@ export default StyleSheet.create({
     height: "100%",
     borderRadius: 3,
   },
-  row2Right: {
+  buffRow: {
     flexDirection: "row",
     alignItems: "center",
     gap: Spacing.tiny,
-  },
-  rewardPill: {
-    paddingHorizontal: Spacing.small,
-    height: 28,
-    borderRadius: Radii.md,
-    backgroundColor: Colors.surface,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  rewardText: {
-    ...Typography.caption,
-    color: Colors.text,
   },
   buffIcon: {
     height: 28,
@@ -103,6 +126,10 @@ export default StyleSheet.create({
     backgroundColor: Colors.surface,
     justifyContent: "center",
     alignItems: "center",
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: Colors.overlay,
   },
 });
 

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -41,10 +41,6 @@ export default function HomeScreen() {
     scrollRef.current?.scrollTo({ y: anchors.shop, animated: true });
   }, [anchors.shop]);
 
-  const scrollToReward = useCallback(() => {
-    scrollRef.current?.scrollTo({ y: anchors.reward, animated: true });
-  }, [anchors.reward]);
-
   const goToTasks = useCallback(() => {
     navigation.navigate("Tasks");
   }, [navigation]);
@@ -58,7 +54,7 @@ export default function HomeScreen() {
           onClose={() => dispatch({ type: "CLEAR_ACHIEVEMENT_TOAST" })}
         />
       )}
-      <HomeHeader onPressDailyReward={scrollToReward} />
+      <HomeHeader />
       <ScrollView
         ref={scrollRef}
         contentContainerStyle={styles.content}
@@ -67,7 +63,7 @@ export default function HomeScreen() {
         <View onLayout={setAnchor("welcome")}>
           <HomeWelcomeCard onNext={goToTasks} />
         </View>
-        <View onLayout={setAnchor("reward")}>
+        <View>
           <DailyRewardSection />
         </View>
         <View onLayout={setAnchor("challenges")}>

--- a/src/screens/RewardsScreen.js
+++ b/src/screens/RewardsScreen.js
@@ -1,0 +1,102 @@
+// [MB] Módulo: Home / Sección: RewardsScreen
+// Afecta: flujo de Recompensas
+// Propósito: Pantalla mock de ejemplos de recompensas
+// Puntos de edición futura: convertir en UI interactiva y dinámica
+// Autor: Codex - Fecha: 2025-08-30
+
+import React from "react";
+import { ScrollView, View, Text, StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Typography,
+  Elevation,
+  Opacity,
+} from "../theme";
+
+export default function RewardsScreen() {
+  const Card = ({ title, reward }) => (
+    <View
+      style={styles.card}
+      pointerEvents="none"
+      accessibilityRole="text"
+      accessibilityLabel={`Ejemplo (no interactivo): ${title} — ${reward}`}
+    >
+      <Text style={styles.cardTitle}>{title}</Text>
+      <View style={styles.rewardChip}>
+        <Text style={styles.rewardChipText}>{reward}</Text>
+      </View>
+      <Text style={styles.exampleTag}>Ejemplo</Text>
+    </View>
+  );
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.sectionTitle}>Social</Text>
+        <Card title="Seguir en Instagram" reward="+10 diamantes" />
+        <Card title="Unirte a Discord" reward="+1 buff (24h)" />
+
+        <Text style={styles.sectionTitle}>Compartir/Referidos</Text>
+        <Card title="Compartir tu link" reward="+15 maná" />
+        <Card title="Invitar a un amigo (1ª misión)" reward="+20 XP" />
+
+        <Text style={styles.sectionTitle}>Progresión</Text>
+        <Card title="Completar 5 tareas hoy" reward="+50 XP" />
+        <Card title="Racha de 7 días" reward="+100 XP" />
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.background,
+  },
+  content: {
+    padding: Spacing.base,
+    gap: Spacing.base,
+  },
+  sectionTitle: {
+    ...Typography.h2,
+    color: Colors.text,
+    marginTop: Spacing.base,
+  },
+  card: {
+    backgroundColor: Colors.surfaceElevated,
+    borderColor: Colors.border,
+    borderWidth: 1,
+    borderRadius: Radii.lg,
+    padding: Spacing.base,
+    opacity: Opacity.muted || 0.7,
+    ...Elevation.raised,
+    marginTop: Spacing.small,
+  },
+  cardTitle: {
+    ...Typography.body,
+    color: Colors.text,
+    marginBottom: Spacing.small,
+  },
+  rewardChip: {
+    alignSelf: "flex-start",
+    backgroundColor: Colors.accent,
+    borderRadius: Radii.sm,
+    paddingHorizontal: Spacing.small,
+    paddingVertical: Spacing.tiny,
+  },
+  rewardChipText: {
+    ...Typography.caption,
+    color: Colors.onAccent,
+  },
+  exampleTag: {
+    position: "absolute",
+    top: Spacing.small,
+    right: Spacing.small,
+    ...Typography.caption,
+    color: Colors.textMuted,
+  },
+});
+


### PR DESCRIPTION
## Summary
- overhaul HomeHeader with top bar, chip row and animated popovers
- remove daily reward pill and keep level/XP block
- add mock RewardsScreen and navigation route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d79066e6483279cb3b6e922d88d02