### PR TITLE
feat: reorganize home header chips

### DIFF
--- a/src/components/home/HomeHeader.styles.js
+++ b/src/components/home/HomeHeader.styles.js
@@ -2,7 +2,7 @@
 // Afecta: HomeHeader
 // Propósito: Estilos para top bar, chips y popovers del encabezado
 // Puntos de edición futura: ajustar tamaños de chip y responsividad
-// Autor: Codex - Fecha: 2025-08-30
+// Autor: Codex - Fecha: 2025-08-14
 
 import { StyleSheet } from "react-native";
 import { Colors, Spacing, Radii, Typography, Elevation } from "../../theme";
@@ -20,14 +20,22 @@ export default StyleSheet.create({
     justifyContent: "space-between",
     alignItems: "center",
   },
-  topBarRight: {
+  titleRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: Spacing.tiny,
+    gap: Spacing.small,
   },
   title: {
     ...Typography.title,
     color: Colors.text,
+  },
+  plantChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: Colors.surface,
+    borderRadius: Radii.lg,
+    paddingHorizontal: Spacing.small,
+    height: 28,
   },
   iconButton: {
     padding: Spacing.tiny,
@@ -43,15 +51,15 @@ export default StyleSheet.create({
   },
   chipRow: {
     flexDirection: "row",
-    justifyContent: "space-between",
+    flexWrap: "wrap",
     alignItems: "center",
-    gap: Spacing.small,
+    gap: Spacing.tiny,
   },
   chip: {
     flexDirection: "row",
     alignItems: "center",
     backgroundColor: Colors.surface,
-    borderRadius: Radii.lg,
+    borderRadius: Radii.md,
     paddingHorizontal: Spacing.small,
     height: 28,
   },
@@ -62,16 +70,9 @@ export default StyleSheet.create({
     ...Typography.caption,
     color: Colors.text,
   },
-  popoverRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
+  popoverContainer: {
     marginTop: Spacing.small,
-  },
-  popoverSlot: {
-    flex: 1,
-    alignItems: "center",
-  },
-  popover: {
+    width: "100%",
     backgroundColor: Colors.surfaceElevated,
     borderColor: Colors.border,
     borderWidth: 1,
@@ -127,9 +128,4 @@ export default StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
   },
-  overlay: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: Colors.overlay,
-  },
 });
-

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -2,10 +2,10 @@
 // Afecta: HomeScreen (layout principal)
 // Propósito: Renderizar secciones de inicio y mostrar estado global
 // Puntos de edición futura: conectar datos reales y navegación
-// Autor: Codex - Fecha: 2025-08-13
+// Autor: Codex - Fecha: 2025-08-14
 
 import React, { useRef, useState, useCallback } from "react";
-import { StyleSheet, ScrollView, View } from "react-native";
+import { StyleSheet, ScrollView, View, Pressable } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Colors, Spacing } from "../theme";
 import HomeHeader from "../components/home/HomeHeader";
@@ -25,7 +25,10 @@ export default function HomeScreen() {
   const achievementToast = useAchievementToast();
   const dispatch = useAppDispatch();
   const scrollRef = useRef(null);
+  const headerRef = useRef(null);
   const [anchors, setAnchors] = useState({});
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const [isChipPopoverOpen, setChipPopoverOpen] = useState(false);
   const navigation = useNavigation();
 
   const setAnchor = useCallback(
@@ -54,7 +57,13 @@ export default function HomeScreen() {
           onClose={() => dispatch({ type: "CLEAR_ACHIEVEMENT_TOAST" })}
         />
       )}
-      <HomeHeader />
+      <HomeHeader
+        ref={headerRef}
+        onHeaderLayout={(e) =>
+          setHeaderHeight(e?.nativeEvent?.layout?.height || 0)
+        }
+        onChipPopoverToggle={setChipPopoverOpen}
+      />
       <ScrollView
         ref={scrollRef}
         contentContainerStyle={styles.content}
@@ -85,6 +94,14 @@ export default function HomeScreen() {
           <EventBanner />
         </View>
       </ScrollView>
+      {isChipPopoverOpen && (
+        <Pressable
+          style={[styles.overlay, { top: headerHeight }]}
+          onPress={() => headerRef.current?.closePopover()}
+          accessibilityRole="button"
+          accessibilityLabel="Capa de fondo: toque para cerrar popover"
+        />
+      )}
     </SafeAreaView>
   );
 }
@@ -101,5 +118,12 @@ const styles = StyleSheet.create({
     paddingTop: Spacing.base,
     paddingBottom: 96,
     gap: Spacing.large,
+  },
+  overlay: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: Colors.overlay,
   },
 });


### PR DESCRIPTION
## Summary
- move plant status chip beside title and remove settings button
- split resource chips and add animated popovers with accessible overlay
- handle overlay in HomeScreen positioned below header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d7f910a2c8327b0e6218bd3f78ac8