### PR TITLE
style: separate tags into second row

### DIFF
--- a/src/components/TaskCard/TaskCard.js
+++ b/src/components/TaskCard/TaskCard.js
@@ -18,8 +18,6 @@ import styles from "./TaskCardStyles";
 
 import { Colors, Spacing } from "../../theme";
 
-const CHIP_GAP = Spacing.small - Spacing.tiny / 2;
-
 const ElementAccents = {
   water: Colors.elementWater,
   earth: Colors.elementEarth,
@@ -369,7 +367,7 @@ export default function TaskCard({
           </>
         )}
 
-        {/* ——— Chips de metadatos, etiquetas y recompensas ——— */}
+        {/* ——— Chips de metadatos y recompensas ——— */}
         <View style={styles.metaRow}>
           <View style={styles.chip} accessibilityRole="text">
             <Text style={styles.chipText}>{typeLabel}</Text>
@@ -390,33 +388,30 @@ export default function TaskCard({
               {getPriorityLabel(task.priority)}
             </Text>
           </View>
-          {task.tags?.length > 0 && (
-            <View style={styles.tagsContainer}>
-              {task.tags.map((tag) => (
-                <View key={tag} style={styles.tagChip} accessibilityRole="text">
-                  <Text
-                    style={styles.tagText}
-                    numberOfLines={1}
-                    ellipsizeMode="tail"
-                  >
-                    {tag}
-                  </Text>
-                </View>
-              ))}
-            </View>
-          )}
           <Text
             style={[
               styles.rewardInlineText,
-              {
-                color: getPriorityColor(task.priority),
-                marginLeft: task.tags?.length ? CHIP_GAP : "auto",
-              },
+              { color: getPriorityColor(task.priority) },
             ]}
             numberOfLines={1}
             ellipsizeMode="tail"
           >{`+${xp} XP · +${mana} ⚡`}</Text>
         </View>
+        {task.tags?.length > 0 && (
+          <View style={styles.tagsRow}>
+            {task.tags.map((tag) => (
+              <View key={tag} style={styles.tagChip} accessibilityRole="text">
+                <Text
+                  style={styles.tagText}
+                  numberOfLines={1}
+                  ellipsizeMode="tail"
+                >
+                  {tag}
+                </Text>
+              </View>
+            ))}
+          </View>
+        )}
         </View>
         <View style={styles.rightColumn}>
           <TouchableOpacity

--- a/src/components/TaskCard/TaskCardStyles.js
+++ b/src/components/TaskCard/TaskCardStyles.js
@@ -172,14 +172,14 @@ export default StyleSheet.create({
 
   metaRow: {
     flexDirection: "row",
-    alignItems: "flex-start",
+    alignItems: "baseline",
     flexWrap: "nowrap",
     gap: Spacing.small - Spacing.tiny / 2,
   },
 
   chip: {
-    height: Spacing.base + Spacing.small + Spacing.tiny,
-    paddingHorizontal: Spacing.small + Spacing.tiny,
+    height: Spacing.base + Spacing.small,
+    paddingHorizontal: Spacing.small,
     borderRadius: Radii.pill,
     justifyContent: "center",
     alignItems: "center",
@@ -205,11 +205,11 @@ export default StyleSheet.create({
     flexShrink: 1,
     maxWidth: "100%",
   },
-  tagsContainer: {
+  tagsRow: {
     flexDirection: "row",
-    flexShrink: 1,
     flexWrap: "wrap",
     gap: Spacing.small - Spacing.tiny / 2,
+    marginTop: Spacing.small,
   },
   tagText: {
     ...Typography.caption,


### PR DESCRIPTION
## Summary
- keep type, priority and reward in single meta row without wrapping
- render task tags in dedicated second row with wrap and spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d83cdbba48327beb2378ca7ad86ab