### PR TITLE
[MB] HomeHeader — Fix iconos invisibles (color, estructura y capas)

### DIFF
--- a/src/components/home/HomeHeader.js
+++ b/src/components/home/HomeHeader.js
@@ -87,8 +87,8 @@ function HomeHeader(
         <Ionicons
           name="leaf"
           size={14}
-          color={Colors.text}
-          style={styles.chipIcon}
+          color={Colors.icon}
+          style={styles.icon}
         />
       ),
       label: plantState || "--",
@@ -102,8 +102,8 @@ function HomeHeader(
         <Ionicons
           name="water"
           size={14}
-          color={Colors.text}
-          style={styles.chipIcon}
+          color={Colors.icon}
+          style={styles.icon}
         />
       ),
       label: String(mana),
@@ -117,8 +117,8 @@ function HomeHeader(
         <FontAwesome5
           name="coins"
           size={12}
-          color={Colors.text}
-          style={styles.chipIcon}
+          color={Colors.icon}
+          style={styles.icon}
         />
       ),
       label: String(coin),
@@ -132,8 +132,8 @@ function HomeHeader(
         <FontAwesome5
           name="gem"
           size={12}
-          color={Colors.text}
-          style={styles.chipIcon}
+          color={Colors.icon}
+          style={styles.icon}
         />
       ),
       label: String(gem),
@@ -147,8 +147,8 @@ function HomeHeader(
         <FontAwesome5
           name="fire"
           size={12}
-          color={Colors.text}
-          style={styles.chipIcon}
+          color={Colors.icon}
+          style={styles.icon}
         />
       ),
       label: String(streak),
@@ -162,8 +162,8 @@ function HomeHeader(
         <Ionicons
           name="flask"
           size={14}
-          color={Colors.text}
-          style={styles.chipIcon}
+          color={Colors.icon}
+          style={styles.icon}
         />
       ),
       label: String(buffs.length),
@@ -179,8 +179,8 @@ function HomeHeader(
         <Ionicons
           name="gift"
           size={14}
-          color={Colors.text}
-          style={styles.chipIcon}
+          color={Colors.icon}
+          style={styles.icon}
         />
       ),
       label: "Ver",
@@ -240,29 +240,34 @@ function HomeHeader(
       <View style={styles.topBar}>
         <View style={styles.titleRow}>
           <Text style={styles.title}>Mana Bloom</Text>
-          <Pressable
-            onPress={() =>
-              activeChip === "plant" ? closePopover() : openChip("plant")
-            }
-            style={styles.plantChip}
-            disabled={popoverOpen && activeChip !== "plant"}
-            accessibilityRole="button"
-            accessibilityLabel={chipConfig.plant.a11y}
-            accessibilityState={
-              activeChip === "plant" ? { expanded: true } : undefined
-            }
-            hitSlop={chipHitSlop}
-          >
-            {chipConfig.plant.icon}
-            <Text
-              style={styles.chipText}
-              numberOfLines={1}
-              ellipsizeMode="tail"
-            >
-              {chipConfig.plant.label}
-            </Text>
-          </Pressable>
-        </View>
+        <Pressable
+          onPress={() =>
+            activeChip === "plant" ? closePopover() : openChip("plant")
+          }
+          style={[
+            styles.plantChip,
+            popoverOpen && activeChip !== "plant" && styles.chipDisabled,
+          ]}
+          disabled={popoverOpen && activeChip !== "plant"}
+          accessibilityRole="button"
+          accessibilityLabel={chipConfig.plant.a11y}
+          accessibilityState={
+            activeChip === "plant" ? { expanded: true } : undefined
+          }
+          hitSlop={chipHitSlop}
+        >
+            <View style={styles.chipContent}>
+              {chipConfig.plant.icon}
+              <Text
+                style={styles.chipText}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
+                {chipConfig.plant.label}
+              </Text>
+            </View>
+        </Pressable>
+      </View>
         <Pressable
           onPress={onPressNotifications}
           style={styles.iconButton}
@@ -272,7 +277,8 @@ function HomeHeader(
           <Ionicons
             name="notifications-outline"
             size={18}
-            color={Colors.text}
+            color={Colors.icon}
+            style={styles.icon}
           />
         </Pressable>
       </View>
@@ -291,7 +297,10 @@ function HomeHeader(
                     ? closePopover()
                     : openChip(c.key)
                 }
-                style={styles.chip}
+                style={[
+                  styles.chip,
+                  popoverOpen && activeChip !== c.key && styles.chipDisabled,
+                ]}
                 disabled={popoverOpen && activeChip !== c.key}
                 accessibilityRole="button"
                 accessibilityLabel={c.a11y}
@@ -300,14 +309,16 @@ function HomeHeader(
                 }
                 hitSlop={chipHitSlop}
               >
-                {c.icon}
-                <Text
-                  style={styles.chipText}
-                  numberOfLines={1}
-                  ellipsizeMode="tail"
-                >
-                  {c.label}
-                </Text>
+                <View style={styles.chipContent}>
+                  {c.icon}
+                  <Text
+                    style={styles.chipText}
+                    numberOfLines={1}
+                    ellipsizeMode="tail"
+                  >
+                    {c.label}
+                  </Text>
+                </View>
               </Pressable>
             );
           })}

--- a/src/components/home/HomeHeader.styles.js
+++ b/src/components/home/HomeHeader.styles.js
@@ -2,10 +2,10 @@
 // Afecta: HomeHeader
 // Propósito: Estilos para top bar, chips y popovers del encabezado
 // Puntos de edición futura: ajustar tamaños de chip y responsividad
-// Autor: Codex - Fecha: 2025-08-14
+// Autor: Codex - Fecha: 2025-08-16
 
 import { StyleSheet } from "react-native";
-import { Colors, Spacing, Radii, Typography, Elevation } from "../../theme";
+import { Colors, Spacing, Radii, Typography, Elevation, Opacity } from "../../theme";
 
 export default StyleSheet.create({
   container: {
@@ -14,6 +14,7 @@ export default StyleSheet.create({
     paddingTop: Spacing.base,
     paddingBottom: Spacing.small,
     ...Elevation.raised,
+    zIndex: 2,
   },
   topBar: {
     flexDirection: "row",
@@ -30,11 +31,10 @@ export default StyleSheet.create({
     color: Colors.text,
   },
   plantChip: {
-    flexDirection: "row",
-    alignItems: "center",
     backgroundColor: Colors.surface,
     borderRadius: Radii.lg,
     paddingHorizontal: Spacing.small,
+    paddingVertical: Spacing.tiny,
     height: Spacing.large + Spacing.tiny,
   },
   iconButton: {
@@ -59,8 +59,6 @@ export default StyleSheet.create({
     gap: Spacing.small,
   },
   chip: {
-    flexDirection: "row",
-    alignItems: "center",
     backgroundColor: Colors.surface,
     borderRadius: Radii.lg,
     paddingHorizontal: Spacing.small,
@@ -71,8 +69,19 @@ export default StyleSheet.create({
     flexGrow: 0,
     marginBottom: Spacing.small,
   },
-  chipIcon: {
-    marginRight: Spacing.tiny,
+  chipContent: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Spacing.tiny,
+  },
+  icon: {
+    color: Colors.icon,
+  },
+  iconOnAccent: {
+    color: Colors.onAccent,
+  },
+  chipDisabled: {
+    opacity: Opacity.disabled,
   },
   chipText: {
     ...Typography.caption,

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -2,7 +2,7 @@
 // Afecta: HomeScreen (layout principal)
 // Propósito: Renderizar secciones de inicio y mostrar estado global
 // Puntos de edición futura: conectar datos reales y navegación
-// Autor: Codex - Fecha: 2025-08-14
+// Autor: Codex - Fecha: 2025-08-16
 
 import React, { useRef, useState, useCallback } from "react";
 import { StyleSheet, ScrollView, View, Pressable } from "react-native";
@@ -126,5 +126,6 @@ const styles = StyleSheet.create({
   },
   overlay: {
     backgroundColor: Colors.overlay,
+    zIndex: 1,
   },
 });

--- a/src/theme.js
+++ b/src/theme.js
@@ -3,7 +3,7 @@
    Afecta: toda la app (colores, espaciado, tipografía, radios, elevación)
    Propósito: unificar estilos y facilitar que Codex y yo creemos UI coherente
    Puntos de edición futura: Typography, Radii
-   Autor: Codex - Fecha: 2025-08-13
+   Autor: Codex - Fecha: 2025-08-16
 */
 
 export const Colors = {
@@ -39,6 +39,7 @@ export const Colors = {
   text: "#FFFFFF",
   textMuted: "#b0bec5",
   textInverse: "#0e0a1e",
+  icon: "#FFFFFF",
 
   // Controles
   buttonBg: "#00B4D8",


### PR DESCRIPTION
## Summary
- add Colors.icon token for neutral icons on dark surfaces
- explicitly color HomeHeader icons and move them outside Text
- ensure overlay sits below header using zIndex

## Testing
- `npm test`
- `npx expo-doctor` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_689fd6232cf48327a50ce0b98fc9b139