### PR TITLE
feat(plant): métricas de cuidado (pills animadas, estados y a11y)

### DIFF
--- a/src/components/plant/CareMetrics.js
+++ b/src/components/plant/CareMetrics.js
@@ -1,0 +1,110 @@
+// [MB] Módulo: Planta / Sección: Métricas de cuidado
+// Afecta: PlantScreen (grupo de indicadores)
+// Propósito: agrupar barras de agua, luz, nutrientes y ánimo
+// Puntos de edición futura: fuentes de datos reales
+// Autor: Codex - Fecha: 2025-08-16
+
+import React from "react";
+import { View, StyleSheet, useWindowDimensions } from "react-native";
+import { FontAwesome5 } from "@expo/vector-icons";
+import MetricPill from "./MetricPill";
+import { Colors, Spacing } from "../../theme";
+
+// type MetricValue = number | undefined; ver spec en tarea
+export default function CareMetrics({
+  water,
+  light,
+  nutrients,
+  mood,
+  style,
+}) {
+  const { width } = useWindowDimensions();
+  const isCompact = width < 400; // [MB] Corte simple para 1×4 en pantallas estrechas
+
+  const metrics = [
+    {
+      key: "water",
+      label: "Agua",
+      value: water,
+      accentKey: "water",
+      icon: (
+        <FontAwesome5
+          name="tint"
+          size={Spacing.base}
+          color={Colors.icon}
+        />
+      ),
+    },
+    {
+      key: "light",
+      label: "Luz",
+      value: light,
+      accentKey: "light",
+      icon: (
+        <FontAwesome5
+          name="sun"
+          size={Spacing.base}
+          color={Colors.icon}
+        />
+      ),
+    },
+    {
+      key: "nutrients",
+      label: "Nutrientes",
+      value: nutrients,
+      accentKey: "nutrients",
+      icon: (
+        <FontAwesome5
+          name="leaf"
+          size={Spacing.base}
+          color={Colors.icon}
+        />
+      ),
+    },
+    {
+      key: "mood",
+      label: "Ánimo",
+      value: mood,
+      accentKey: "mood",
+      icon: (
+        <FontAwesome5
+          name="smile"
+          size={Spacing.base}
+          color={Colors.icon}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { gap: Spacing.base },
+        style,
+      ]}
+    >
+      {metrics.map((m) => (
+        <View
+          key={m.key}
+          style={{ flexBasis: isCompact ? "100%" : "48%" }}
+        >
+          <MetricPill
+            icon={m.icon}
+            label={m.label}
+            value={m.value}
+            accentKey={m.accentKey}
+          />
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+  },
+});
+

--- a/src/components/plant/MetricPill.js
+++ b/src/components/plant/MetricPill.js
@@ -1,0 +1,148 @@
+// [MB] Módulo: Planta / Sección: Métricas de cuidado
+// Afecta: PlantScreen (píldora individual)
+// Propósito: barra animada para una métrica de cuidado
+// Puntos de edición futura: ajustes de estado/colores
+// Autor: Codex - Fecha: 2025-08-16
+
+import React, { useEffect, useRef, useState } from "react";
+import { View, Text, Animated, StyleSheet } from "react-native";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Typography,
+  Opacity,
+} from "../../theme";
+
+// [MB] Mapas de acentos desde tokens; sin hardcodes
+const ElementAccents = {
+  water: Colors.elementWater,
+  light: Colors.secondary,
+  nutrients: Colors.elementEarth,
+  mood: Colors.primary,
+};
+
+const ElementAccentsLight = {
+  water: Colors.elementWaterLight,
+  light: Colors.secondaryLight,
+  nutrients: Colors.elementEarthLight,
+  mood: Colors.primaryLight,
+};
+
+const LOW = 0.35;
+const HIGH = 0.8;
+
+export default function MetricPill({ icon, label, value, accentKey }) {
+  const [trackWidth, setTrackWidth] = useState(0);
+  const anim = useRef(new Animated.Value(0)).current;
+
+  // [MB] Animación de llenado al montar/actualizar
+  useEffect(() => {
+    if (value === undefined) {
+      anim.setValue(0);
+      return;
+    }
+    Animated.timing(anim, {
+      toValue: value,
+      duration: 400,
+      useNativeDriver: false,
+    }).start();
+  }, [value, anim]);
+
+  const state = getState(value);
+  const accentBase = ElementAccents[accentKey] || Colors.accent;
+  const accentLight = ElementAccentsLight[accentKey];
+  const fillColor = state === "low" && accentLight ? accentLight : accentBase;
+  const fillOpacity = state === "low" ? 0.6 : state === "high" ? 1 : 0.85;
+
+  const width = anim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, trackWidth],
+  });
+
+  const percent = value !== undefined ? Math.round(value * 100) : undefined;
+  const stateLabel =
+    state === "low"
+      ? "bajo"
+      : state === "high"
+      ? "alto"
+      : state === "ok"
+      ? "OK"
+      : "sin datos";
+
+  return (
+    <View
+      style={[styles.track, { opacity: value === undefined ? Opacity.disabled : 1 }]}
+      onLayout={(e) => setTrackWidth(e.nativeEvent.layout.width)}
+      accessibilityRole="progressbar"
+      accessibilityLabel={`${label}, ${
+        percent !== undefined ? percent + " %" : "sin datos"
+      }, estado ${stateLabel}`}
+      accessibilityValue={
+        value !== undefined ? { min: 0, max: 100, now: percent } : undefined
+      }
+    >
+      {/* [MB] Barra de relleno animada */}
+      <Animated.View
+        style={[
+          styles.fill,
+          { width, backgroundColor: fillColor, opacity: fillOpacity },
+        ]}
+      />
+      {/* [MB] Contenido textual/iconográfico */}
+      <View style={styles.content}>
+        <View style={styles.left}>
+          {icon}
+          <Text style={styles.label}>{label}</Text>
+        </View>
+        <Text style={styles.value}>
+          {percent !== undefined ? `${percent}%` : "Sin datos"}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+function getState(v) {
+  if (v === undefined) return "none";
+  if (v < LOW) return "low";
+  if (v > HIGH) return "high";
+  return "ok";
+}
+
+const styles = StyleSheet.create({
+  track: {
+    position: "relative",
+    justifyContent: "center",
+    height: Spacing.large,
+    borderRadius: Radii.pill,
+    backgroundColor: Colors.surfaceAlt,
+    overflow: "hidden",
+    paddingHorizontal: Spacing.base,
+  },
+  fill: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+    bottom: 0,
+  },
+  content: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  left: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  label: {
+    ...Typography.body,
+    color: Colors.text,
+    marginLeft: Spacing.small,
+  },
+  value: {
+    ...Typography.caption,
+    color: Colors.textMuted,
+  },
+});
+

--- a/src/screens/PlantScreen.js
+++ b/src/screens/PlantScreen.js
@@ -7,6 +7,7 @@
 import React from "react";
 import { SafeAreaView, ScrollView, StyleSheet } from "react-native";
 import PlantHero from "../components/plant/PlantHero";
+import CareMetrics from "../components/plant/CareMetrics";
 import { Colors, Spacing } from "../theme";
 
 export default function PlantScreen() {
@@ -16,6 +17,14 @@ export default function PlantScreen() {
       <ScrollView contentContainerStyle={styles.content}>
         {/* [MB] Hero de planta */}
         <PlantHero health={0.95} mood="floreciente" stage="brote" />
+        {/* [MB] Métricas de cuidado */}
+        <CareMetrics
+          water={0.62}
+          light={0.48}
+          nutrients={0.3}
+          mood={0.95}
+          style={{ alignSelf: "stretch", marginTop: Spacing.large }}
+        />
       </ScrollView>
     </SafeAreaView>
   );


### PR DESCRIPTION
## Summary
- add animated MetricPill component with color-coded states and accessibility
- aggregate four care metrics with responsive grid in CareMetrics
- integrate CareMetrics into PlantScreen beneath PlantHero

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fdbcb0b308327a0a8540c3c533e47