### PR TITLE
feat(plant): progreso de crecimiento con barra animada y mini log

### DIFF
--- a/src/components/plant/GrowthMilestoneItem.js
+++ b/src/components/plant/GrowthMilestoneItem.js
@@ -1,0 +1,79 @@
+// [MB] Módulo: Planta / Sección: Progreso de crecimiento
+// Afecta: PlantScreen (mini log)
+// Propósito: renderiza un hito reciente de cuidado con icono y timestamp relativo
+// Puntos de edición futura: mover estilos a .styles.js o agregar soporte de i18n
+// Autor: Codex - Fecha: 2025-08-18
+
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { Colors, Spacing, Typography, Opacity } from "../../theme";
+
+export default function GrowthMilestoneItem({ icon, title, delta, timestamp }) {
+  const relative = formatRelative(timestamp);
+  const accessibilityLabel = `Hito: ${title}${delta ? `, ${delta}` : ""}, ${relative}`;
+
+  return (
+    <View
+      // [MB] Cada hito se expone como texto accesible compuesto
+      accessibilityRole="text"
+      accessibilityLabel={accessibilityLabel}
+      style={styles.container}
+    >
+      {/* [MB] Primera fila: icono, título y delta */}
+      <View style={styles.row}>
+        {icon ? (
+          typeof icon === "string" ? (
+            <Text style={styles.icon}>{icon}</Text>
+          ) : (
+            <View style={styles.icon}>{icon}</View>
+          )
+        ) : null}
+        <Text style={styles.title}>{title}</Text>
+        {delta ? <Text style={styles.delta}>{delta}</Text> : null}
+      </View>
+      {/* [MB] Segunda fila: timestamp relativo */}
+      <Text style={styles.time}>{relative}</Text>
+    </View>
+  );
+}
+
+function formatRelative(ts) {
+  // [MB] Formato simple relativo en segundos/minutos/horas/días
+  const diff = Math.floor((Date.now() - ts) / 1000);
+  if (diff < 60) return `hace ${diff}s`;
+  if (diff < 3600) return `hace ${Math.floor(diff / 60)}m`;
+  if (diff < 86400) return `hace ${Math.floor(diff / 3600)}h`;
+  return `hace ${Math.floor(diff / 86400)}d`;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: Spacing.small,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  icon: {
+    marginRight: Spacing.small,
+  },
+  title: {
+    ...Typography.body,
+    color: Colors.text,
+    flex: 1,
+  },
+  delta: {
+    ...Typography.body,
+    color: Colors.text,
+    opacity: Opacity.muted,
+    marginLeft: Spacing.small,
+  },
+  time: {
+    ...Typography.caption,
+    color: Colors.text,
+    opacity: Opacity.muted,
+    marginTop: Spacing.tiny,
+  },
+});
+

--- a/src/components/plant/GrowthProgress.js
+++ b/src/components/plant/GrowthProgress.js
@@ -1,0 +1,236 @@
+// [MB] Módulo: Planta / Sección: Progreso de crecimiento
+// Afecta: PlantScreen (barra y log)
+// Propósito: mostrar etapa actual, progreso animado y últimos hitos
+// Puntos de edición futura: extraer colores de stage y consolidar estilos
+// Autor: Codex - Fecha: 2025-08-18
+
+import React, { useEffect, useRef, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Animated,
+  Easing,
+} from "react-native";
+import GrowthMilestoneItem from "./GrowthMilestoneItem";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Elevation,
+  Typography,
+  Opacity,
+} from "../../theme";
+
+// [MB] Acentos para crecimiento
+const ElementAccents = {
+  growth: Colors.primaryFantasy,
+};
+
+function getStageVisual(stage) {
+  // [MB] Mapa sencillo de etapa a emoji
+  const map = {
+    semilla: { emoji: "🌰", accentKey: "growth" },
+    brote: { emoji: "🌱", accentKey: "growth" },
+    planta: { emoji: "🌿", accentKey: "growth" },
+  };
+  return map[stage] || { emoji: "🌱", accentKey: "growth" };
+}
+
+export default function GrowthProgress({
+  stage,
+  progress,
+  etaText,
+  milestones = [],
+  style,
+}) {
+  const { emoji, accentKey } = getStageVisual(stage);
+  const accent = ElementAccents[accentKey || "growth"] || Colors.primary;
+
+  const percent = Math.round(progress * 100);
+
+  // [MB] Animación de fill de la barra
+  const anim = useRef(new Animated.Value(0)).current;
+  const [trackWidth, setTrackWidth] = useState(0);
+  useEffect(() => {
+    Animated.timing(anim, {
+      toValue: progress,
+      duration: 400,
+      easing: Easing.inOut(Easing.quad),
+      useNativeDriver: false,
+    }).start();
+  }, [progress, anim]);
+  const barWidth = anim.interpolate({ inputRange: [0, 1], outputRange: [0, trackWidth] });
+
+  // [MB] Halo y escala al cambiar de etapa
+  const prevStage = useRef(stage);
+  const badgeScale = useRef(new Animated.Value(1)).current;
+  const haloOpacity = useRef(new Animated.Value(0)).current;
+  useEffect(() => {
+    if (prevStage.current !== stage) {
+      prevStage.current = stage;
+      Animated.parallel([
+        Animated.sequence([
+          Animated.timing(badgeScale, {
+            toValue: 1.04,
+            duration: 125,
+            useNativeDriver: true,
+          }),
+          Animated.timing(badgeScale, {
+            toValue: 1,
+            duration: 125,
+            useNativeDriver: true,
+          }),
+        ]),
+        Animated.sequence([
+          Animated.timing(haloOpacity, {
+            toValue: 0.25,
+            duration: 125,
+            useNativeDriver: true,
+          }),
+          Animated.timing(haloOpacity, {
+            toValue: 0,
+            duration: 125,
+            useNativeDriver: true,
+          }),
+        ]),
+      ]).start();
+    }
+  }, [stage, badgeScale, haloOpacity]);
+
+  const accessibleStage = `Etapa: ${stage}, ${percent}% completado`;
+
+  return (
+    <View style={[styles.container, style]}>
+      <Text style={styles.sectionTitle} accessibilityRole="header">
+        Progreso de crecimiento
+      </Text>
+      {/* [MB] Etapa actual con badge y porcentaje */}
+      <View style={styles.header} accessible accessibilityLabel={accessibleStage}>
+        <View style={styles.badgeWrapper}>
+          <Animated.View
+            pointerEvents="none"
+            style={[styles.halo, { backgroundColor: accent, opacity: haloOpacity }]}
+          />
+          <Animated.View style={[styles.badge, { transform: [{ scale: badgeScale }] }]}
+            accessible={false}
+          >
+            <Text style={styles.badgeText}>{emoji}</Text>
+          </Animated.View>
+        </View>
+        <Text style={styles.stageLabel}>{stage}</Text>
+        <Text style={styles.percent}>{percent}%</Text>
+      </View>
+      <View
+        style={styles.barTrack}
+        accessibilityRole="progressbar"
+        accessibilityLabel="Progreso hacia la siguiente etapa"
+        accessibilityValue={{ min: 0, max: 100, now: percent }}
+        onLayout={(e) => setTrackWidth(e.nativeEvent.layout.width)}
+      >
+        <Animated.View style={[styles.barFill, { backgroundColor: accent, width: barWidth }]} />
+      </View>
+      {etaText ? <Text style={styles.eta}>{etaText}</Text> : null}
+      <View style={styles.milestones}>
+        {milestones.length === 0 ? (
+          <View style={styles.empty}>
+            <Text style={styles.emptyIcon}>🕰️</Text>
+            <Text style={styles.emptyText}>Sin eventos recientes</Text>
+          </View>
+        ) : (
+          milestones.slice(0, 5).map((m) => <GrowthMilestoneItem key={m.id} {...m} />)
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: Colors.surfaceElevated,
+    padding: Spacing.large,
+    borderRadius: Radii.lg,
+    ...Elevation.card,
+    alignSelf: "stretch",
+  },
+  sectionTitle: {
+    ...Typography.title,
+    color: Colors.text,
+    marginBottom: Spacing.base,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  badgeWrapper: {
+    width: Spacing.xlarge,
+    height: Spacing.xlarge,
+    marginRight: Spacing.small,
+  },
+  badge: {
+    width: "100%",
+    height: "100%",
+    borderRadius: Radii.pill,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  halo: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    borderRadius: Radii.pill,
+  },
+  badgeText: {
+    fontSize: Spacing.xlarge * 0.75,
+  },
+  stageLabel: {
+    ...Typography.title,
+    color: Colors.text,
+    flex: 1,
+    textAlign: "center",
+  },
+  percent: {
+    ...Typography.title,
+    color: Colors.text,
+  },
+  barTrack: {
+    // [MB] Track con surfaceAlt (no existe surfaceVariant)
+    height: Spacing.small,
+    borderRadius: Radii.pill,
+    backgroundColor: Colors.surfaceAlt,
+    marginTop: Spacing.base,
+    overflow: "hidden",
+  },
+  barFill: {
+    height: "100%",
+    borderRadius: Radii.pill,
+  },
+  eta: {
+    ...Typography.caption,
+    color: Colors.text,
+    opacity: Opacity.muted,
+    marginTop: Spacing.small,
+  },
+  milestones: {
+    marginTop: Spacing.large,
+  },
+  empty: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: Spacing.base,
+  },
+  emptyIcon: {
+    fontSize: Spacing.large,
+    opacity: Opacity.muted,
+    marginBottom: Spacing.small,
+  },
+  emptyText: {
+    ...Typography.body,
+    color: Colors.text,
+    opacity: Opacity.muted,
+  },
+});
+

--- a/src/screens/PlantScreen.js
+++ b/src/screens/PlantScreen.js
@@ -9,6 +9,7 @@ import { SafeAreaView, ScrollView, StyleSheet } from "react-native";
 import PlantHero from "../components/plant/PlantHero";
 import CareMetrics from "../components/plant/CareMetrics";
 import QuickActions from "../components/plant/QuickActions";
+import GrowthProgress from "../components/plant/GrowthProgress";
 import { Colors, Spacing } from "../theme";
 
 export default function PlantScreen() {
@@ -34,6 +35,18 @@ export default function PlantScreen() {
           canMeditate
           cooldowns={{ water: 0, feed: 0, clean: 0, meditate: 0 }}
           onAction={(key) => console.log("[MB] acción", key)}
+        />
+        {/* [MB] Progreso de crecimiento */}
+        <GrowthProgress
+          stage="brote"
+          progress={0.62}
+          etaText="faltan ~3 tareas"
+          milestones={[
+            { id: "m1", icon: "💧", title: "Regaste", delta: "+15 Agua", timestamp: Date.now() - 1000 * 60 * 20 },
+            { id: "m2", icon: "🍃", title: "Aplicaste nutrientes", delta: "+10 Nutrientes", timestamp: Date.now() - 1000 * 60 * 90 },
+            { id: "m3", icon: "🧘", title: "Meditaste", delta: "+10 Ánimo", timestamp: Date.now() - 1000 * 60 * 200 },
+          ]}
+          style={{ alignSelf: "stretch", marginTop: Spacing.large }}
         />
       </ScrollView>
     </SafeAreaView>


### PR DESCRIPTION
## Summary
- add GrowthProgress component with animated progress bar, stage badge and halo flash
- add GrowthMilestoneItem for relative event logging
- integrate growth progress section into PlantScreen with mock milestones

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fe3db937c8327b6289753741bd002