### PR TITLE
fix: ensure HomeHeader icons visible

### DIFF
--- a/src/components/home/HomeHeader.js
+++ b/src/components/home/HomeHeader.js
@@ -40,6 +40,10 @@ const chipHitSlop = {
   right: Spacing.small,
 };
 
+const iconColorSurface = Colors?.icon ?? Colors?.text;
+const iconColorAccent = Colors?.onAccent ?? Colors?.text;
+const ICON_SIZE = 18; // chips de 30px alto
+
 function HomeHeader(
   {
     onPressNotifications = () => {},
@@ -166,6 +170,7 @@ function HomeHeader(
       title: "Recompensas",
       desc: "Explora recompensas disponibles.",
       a11y: "Recompensas",
+      accent: true,
       onPress: () => {
         closePopover();
         navigation.navigate("Rewards");
@@ -232,8 +237,8 @@ function HomeHeader(
             <View style={styles.chipContent}>
               <Icon
                 name={chipConfig.plant.icon}
-                size={18}
-                color={Colors.icon}
+                size={ICON_SIZE}
+                color={iconColorSurface}
                 style={styles.icon}
               />
               <Text
@@ -254,8 +259,8 @@ function HomeHeader(
         >
           <Icon
             name="bell-outline"
-            size={18}
-            color={Colors.icon}
+            size={ICON_SIZE}
+            color={iconColorSurface}
             style={styles.icon}
           />
         </Pressable>
@@ -269,7 +274,7 @@ function HomeHeader(
               <Pressable
                 key={c.key}
                 onPress={c.onPress ? c.onPress : () => onPressChip(c.key)}
-                style={styles.chip}
+                style={[styles.chip, c.accent && styles.chipAccent]}
                 accessibilityRole="button"
                 accessibilityLabel={c.a11y}
                 accessibilityState={
@@ -280,12 +285,12 @@ function HomeHeader(
                 <View style={styles.chipContent}>
                   <Icon
                     name={c.icon}
-                    size={18}
-                    color={Colors.icon}
+                    size={ICON_SIZE}
+                    color={c.accent ? iconColorAccent : iconColorSurface}
                     style={styles.icon}
                   />
                   <Text
-                    style={styles.chipText}
+                    style={c.accent ? styles.chipTextOnAccent : styles.chipText}
                     numberOfLines={1}
                     ellipsizeMode="tail"
                   >

--- a/src/components/home/HomeHeader.styles.js
+++ b/src/components/home/HomeHeader.styles.js
@@ -15,6 +15,7 @@ export default StyleSheet.create({
     paddingBottom: Spacing.small,
     ...Elevation.raised,
     zIndex: 2,
+    position: "relative",
   },
   topBar: {
     flexDirection: "row",
@@ -58,6 +59,7 @@ export default StyleSheet.create({
     alignItems: "center",
     gap: Spacing.small,
     zIndex: 2,
+    position: "relative",
   },
   chip: {
     backgroundColor: Colors.surface,
@@ -69,6 +71,9 @@ export default StyleSheet.create({
     maxWidth: "31%",
     flexGrow: 0,
     marginBottom: Spacing.small,
+  },
+  chipAccent: {
+    backgroundColor: Colors.accent,
   },
   chipContent: {
     flexDirection: "row",
@@ -83,6 +88,10 @@ export default StyleSheet.create({
     ...Typography.caption,
     color: Colors.text,
   },
+  chipTextOnAccent: {
+    ...Typography.caption,
+    color: Colors.onAccent,
+  },
   popoverContainer: {
     marginTop: Spacing.small,
     width: "100%",
@@ -93,6 +102,7 @@ export default StyleSheet.create({
     padding: Spacing.base,
     ...Elevation.raised,
     zIndex: 3,
+    position: "relative",
   },
   popoverTitle: {
     ...Typography.body,

--- a/src/theme.js
+++ b/src/theme.js
@@ -37,9 +37,9 @@ export const Colors = {
 
   // Texto
   text: "#FFFFFF",
+  icon: "#FFFFFF", // same as text for contrast
   textMuted: "#b0bec5",
   textInverse: "#0e0a1e",
-  icon: "#FFFFFF",
 
   // Controles
   buttonBg: "#00B4D8",


### PR DESCRIPTION
## Summary
- add icon color fallbacks using theme token
- adjust HomeHeader chip rendering and styles for icon visibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fe40c277c8327a06b523dc6621f98