### PR TITLE
feat: refine element and task selectors

### DIFF
--- a/src/components/CreateTaskModal/CreateTaskModal.js
+++ b/src/components/CreateTaskModal/CreateTaskModal.js
@@ -107,6 +107,13 @@ const ELEMENT_INFO = {
   },
 };
 
+const ELEMENT_LABELS = {
+  fire: "Fuego",
+  water: "Agua",
+  earth: "Tierra",
+  air: "Aire",
+};
+
 const DIFFS = ["Fácil", "Medio", "Difícil"];
 const DIFF_VALUES = { Fácil: "easy", Medio: "medium", Difícil: "hard" };
 
@@ -338,22 +345,32 @@ export default function CreateTaskModal({
                 setInfoVisible(true);
               }}
             />
-            <View style={styles.whichBlock}>
+            <View
+              style={styles.whichBlock}
+              accessibilityHint="Toca un elemento o mantén presionado para ver más información"
+            >
               <Text style={styles.whichQuestion}>¿Cuál elijo?</Text>
-              <View style={styles.whichRow}>
-                <Text style={styles.whichSnippet} numberOfLines={1}>
-                  {ELEMENT_INFO[newElement]?.description}
-                </Text>
-                <TouchableOpacity
-                  accessibilityRole="button"
-                  onPress={() => {
-                    setInfoElement(newElement);
-                    setInfoVisible(true);
-                  }}
-                >
-                  <Text style={styles.whichMore}>Ver más</Text>
-                </TouchableOpacity>
-              </View>
+              {newElement === "all" ? (
+                <Text style={styles.whichSnippet}>Selecciona un elemento</Text>
+              ) : (
+                <>
+                  <Text style={styles.whichSnippet} numberOfLines={1}>
+                    {ELEMENT_INFO[newElement]?.description}
+                  </Text>
+                  <TouchableOpacity
+                    accessibilityRole="button"
+                    accessibilityLabel={`Ver más sobre ${
+                      ELEMENT_LABELS[newElement] || ""
+                    }`}
+                    onPress={() => {
+                      setInfoElement(newElement);
+                      setInfoVisible(true);
+                    }}
+                  >
+                    <Text style={styles.whichMore}>Ver más</Text>
+                  </TouchableOpacity>
+                </>
+              )}
             </View>
 
               <Text style={styles.sectionLabel}>
@@ -466,7 +483,7 @@ export default function CreateTaskModal({
             </View>
 
             <Text style={styles.sectionLabel}>Dificultad</Text>
-            <View style={styles.chipsContainer}>
+            <View style={styles.difficultyRow}>
               {DIFFS.map((d) => {
                 const val = DIFF_VALUES[d];
                 const selected = newDifficulty === val;
@@ -474,7 +491,7 @@ export default function CreateTaskModal({
                   <Pressable
                     key={d}
                     onPress={() => setNewDifficulty(val)}
-                    style={[styles.chip, selected && styles.chipActive]}
+                    style={[styles.difficultyChip, selected && styles.chipActive]}
                     accessibilityRole="button"
                     accessibilityState={{ selected }}
                     accessibilityLabel={`Dificultad ${d}`}

--- a/src/components/CreateTaskModal/CreateTaskModal.styles.js
+++ b/src/components/CreateTaskModal/CreateTaskModal.styles.js
@@ -135,18 +135,14 @@ export default StyleSheet.create({
     color: Colors.text,
   },
   whichRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
     marginTop: Spacing.tiny,
   },
   whichSnippet: {
-    flex: 1,
     fontSize: 12,
     color: Colors.textMuted,
-    marginRight: Spacing.small,
+    marginTop: Spacing.tiny,
   },
-  whichMore: { fontSize: 12, color: Colors.info },
+  whichMore: { fontSize: 12, color: Colors.info, marginTop: Spacing.tiny },
 
   subtasksChips: {
     flexDirection: "row",
@@ -178,11 +174,22 @@ export default StyleSheet.create({
   chipLabelActive: {
     color: Colors.background,
   },
-  chipsContainer: {
+  difficultyRow: {
     flexDirection: "row",
-    flexWrap: "wrap",
     gap: Spacing.small,
     marginTop: Spacing.small,
+  },
+  difficultyChip: {
+    flex: 1,
+    minWidth: 0,
+    minHeight: Spacing.xlarge,
+    paddingHorizontal: Spacing.base,
+    borderRadius: Radii?.pill ?? 999,
+    borderWidth: 1,
+    borderColor: Colors.textMuted,
+    backgroundColor: Colors.surface,
+    alignItems: "center",
+    justifyContent: "center",
   },
 
   priorityList: { marginTop: Spacing.small, gap: Spacing.small },
@@ -255,21 +262,24 @@ export default StyleSheet.create({
   tagsList: {
     flexDirection: "row",
     flexWrap: "wrap",
-    gap: Spacing.small,
+    gap: Spacing.small - 2,
     marginTop: Spacing.small,
   },
   tagChip: {
-    minHeight: 28,
+    minHeight: Spacing.large,
     paddingHorizontal: Spacing.base,
     borderRadius: Radii?.pill ?? 999,
     backgroundColor: Colors.surfaceElevated || Colors.surface,
-    borderWidth: 1,
+    borderWidth: StyleSheet.hairlineWidth,
     borderColor: Colors.textMuted,
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
   },
-  tagText: { fontSize: 12, color: Colors.text },
+  tagText: {
+    fontSize: (Typography.caption?.fontSize || 12) - 1,
+    color: Colors.text,
+  },
 
   actions: {
     flexDirection: "row",

--- a/src/components/CreateTaskModal/ElementGrid.js
+++ b/src/components/CreateTaskModal/ElementGrid.js
@@ -6,7 +6,7 @@
 
 import React, { useState, useRef, useEffect } from "react";
 import { View, Pressable, Text, Animated, Easing } from "react-native";
-import { Colors, Spacing, Elevation } from "../../theme";
+import { Colors, Spacing, Elevation, Radii } from "../../theme";
 import styles from "./CreateTaskModal.styles";
 
 const withAlpha = (hex, alpha) => {
@@ -58,11 +58,11 @@ export default function ElementGrid({ value, onChange, onLongPress, tileAspect =
 
 function ElementTile({ element, index, width, height, selected, onPress, onLongPress }) {
   const accent = ElementAccents[element.key];
-  const scale = useRef(new Animated.Value(selected ? 1 : 0.98)).current;
+  const glowScale = useRef(new Animated.Value(selected ? 1 : 0.98)).current;
   const glowOpacity = useRef(new Animated.Value(selected ? 1 : 0)).current;
 
   useEffect(() => {
-    Animated.timing(scale, {
+    Animated.timing(glowScale, {
       toValue: selected ? 1 : 0.98,
       duration: 150,
       easing: Easing.out(Easing.ease),
@@ -74,7 +74,7 @@ function ElementTile({ element, index, width, height, selected, onPress, onLongP
       easing: Easing.out(Easing.ease),
       useNativeDriver: true,
     }).start();
-  }, [selected, scale, glowOpacity]);
+  }, [selected, glowScale, glowOpacity]);
 
   return (
     <Pressable
@@ -84,13 +84,30 @@ function ElementTile({ element, index, width, height, selected, onPress, onLongP
       accessibilityLabel={`Mantén presionado para ver ayuda de ${element.label}`}
       accessibilityState={{ selected }}
       style={{
-        width: width,
-        height: height,
+        width,
+        height,
         marginRight: index % 2 === 0 ? Spacing.small : 0,
         marginBottom: Spacing.small,
+        borderRadius: Radii.lg,
       }}
     >
       <Animated.View
+        pointerEvents="none"
+        style={[
+          styles.elementGlow,
+          {
+            backgroundColor: withAlpha(accent, 0.26),
+            opacity: glowOpacity,
+            transform: [{ scale: glowScale }],
+            shadowColor: accent,
+            shadowOpacity: 0.8,
+            shadowRadius: 12,
+            elevation: 8,
+            borderRadius: Radii.lg,
+          },
+        ]}
+      />
+      <View
         style={[
           styles.elementTile,
           {
@@ -98,25 +115,10 @@ function ElementTile({ element, index, width, height, selected, onPress, onLongP
             backgroundColor: selected
               ? withAlpha(accent, 0.18)
               : Colors.surface,
-            transform: [{ scale }],
           },
           selected && { ...(Elevation.raised || {}), shadowColor: accent },
         ]}
       >
-        <Animated.View
-          pointerEvents="none"
-          style={[
-            styles.elementGlow,
-            {
-              backgroundColor: withAlpha(accent, 0.26),
-              opacity: glowOpacity,
-              shadowColor: accent,
-              shadowOpacity: 0.8,
-              shadowRadius: 12,
-              elevation: 8,
-            },
-          ]}
-        />
         <Text style={styles.elementEmoji}>{element.emoji}</Text>
         <Text style={styles.elementTitle}>{element.label}</Text>
         <Text
@@ -126,7 +128,7 @@ function ElementTile({ element, index, width, height, selected, onPress, onLongP
         >
           {element.caption}
         </Text>
-      </Animated.View>
+      </View>
     </Pressable>
   );
 }


### PR DESCRIPTION
## Summary
- streamline element selection with animated glow and accessible helper
- ensure priority and difficulty chips style correctly with neutral defaults
- tighten tag chip dimensions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fe719807c83279a3b726a783df264