### PR TITLE
feat(theme): align icon and text colors

### DIFF
--- a/src/components/home/HomeHeader.js
+++ b/src/components/home/HomeHeader.js
@@ -40,9 +40,10 @@ const chipHitSlop = {
   right: Spacing.small,
 };
 
-const iconColorSurface = Colors?.icon ?? Colors?.text;
-const iconColorAccent = Colors?.onAccent ?? Colors?.text;
 const ICON_SIZE = 18; // chips de 30px alto
+// Fallback to text color if icon token is missing
+const iconColorSurface = Colors?.icon ?? Colors.text;
+const iconColorAccent = Colors.onAccent;
 
 function HomeHeader(
   {

--- a/src/components/home/HomeHeader.styles.js
+++ b/src/components/home/HomeHeader.styles.js
@@ -58,8 +58,8 @@ export default StyleSheet.create({
     width: "100%",
     alignItems: "center",
     gap: Spacing.small,
-    zIndex: 2,
     position: "relative",
+    zIndex: 2,
   },
   chip: {
     backgroundColor: Colors.surface,
@@ -101,8 +101,8 @@ export default StyleSheet.create({
     borderRadius: Radii.lg,
     padding: Spacing.base,
     ...Elevation.raised,
-    zIndex: 3,
     position: "relative",
+    zIndex: 3,
   },
   popoverTitle: {
     ...Typography.body,

--- a/src/theme.js
+++ b/src/theme.js
@@ -37,9 +37,9 @@ export const Colors = {
 
   // Texto
   text: "#FFFFFF",
-  icon: "#FFFFFF", // same as text for contrast
   textMuted: "#b0bec5",
   textInverse: "#0e0a1e",
+  icon: "#FFFFFF", // Icons mirror text color for contrast
 
   // Controles
   buttonBg: "#00B4D8",
@@ -55,6 +55,7 @@ export const Colors = {
   elementAir: "#90a4ae",
   elementAirLight: "#cfd8dc",
 };
+
 
 export const Spacing = {
   tiny: 4,


### PR DESCRIPTION
## Summary
- ensure icons reuse text color token for contrast
- rely on shared icon size and accent colors in `HomeHeader`
- tidy `HomeHeader` layout layering with explicit positioning
- declare explicit `Colors.icon` token and fall back to text color in `HomeHeader`

## Testing
- `npm test`
- `npm run web` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689fe798decc8327bdccb7f12bae7eed