### PR TITLE
feat(plant): inventario de macetas con sheet y equipar

### DIFF
--- a/src/components/plant/InventorySheet.js
+++ b/src/components/plant/InventorySheet.js
@@ -1,0 +1,210 @@
+// [MB] Módulo: Planta / Sección: Inventario de macetas
+// Afecta: PlantScreen (sheet de inventario)
+// Propósito: hoja modal con previsualización y grid de skins
+// Puntos de edición futura: mover estilos a archivo separado o conectar con backend
+// Autor: Codex - Fecha: 2025-08-16
+
+import React, { useEffect, useRef, useState } from "react";
+import {
+  Animated,
+  FlatList,
+  Pressable,
+  Text,
+  View,
+  StyleSheet,
+  useWindowDimensions,
+} from "react-native";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Typography,
+  Elevation,
+  Opacity,
+} from "../../theme";
+import PlantHero from "./PlantHero";
+import PotSkinCard from "./PotSkinCard";
+
+// [MB] Acentos para preview (placeholder de maceta)
+const ElementAccents = {
+  neutral: Colors.surfaceAlt,
+  water: Colors.elementWater,
+  spirit: Colors.secondaryFantasy,
+  mana: Colors.primaryFantasy,
+};
+
+const RarityAccents = {
+  common: "neutral",
+  rare: "water",
+  epic: "spirit",
+  legendary: "mana",
+};
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+export default function InventorySheet({
+  visible,
+  skins,
+  selectedId,
+  equippedId,
+  onClose,
+  onSelect,
+  onEquip,
+  onBuy,
+}) {
+  const [mounted, setMounted] = useState(visible);
+  const sheetAnim = useRef(new Animated.Value(0)).current; // 0 oculto, 1 visible
+  const backdropAnim = useRef(new Animated.Value(0)).current;
+  const sheetHeight = useRef(0);
+
+  useEffect(() => {
+    if (visible) {
+      setMounted(true);
+      Animated.parallel([
+        Animated.timing(sheetAnim, {
+          toValue: 1,
+          duration: 300,
+          useNativeDriver: true,
+        }),
+        Animated.timing(backdropAnim, {
+          toValue: 1,
+          duration: 300,
+          useNativeDriver: true,
+        }),
+      ]).start();
+    } else if (mounted) {
+      Animated.parallel([
+        Animated.timing(sheetAnim, {
+          toValue: 0,
+          duration: 300,
+          useNativeDriver: true,
+        }),
+        Animated.timing(backdropAnim, {
+          toValue: 0,
+          duration: 300,
+          useNativeDriver: true,
+        }),
+      ]).start(() => setMounted(false));
+    }
+  }, [visible, mounted, sheetAnim, backdropAnim]);
+
+  const { width } = useWindowDimensions();
+  const numColumns = width < 360 ? 2 : 3;
+
+  const selected = skins.find((s) => s.id === selectedId) || skins.find((s) => s.id === equippedId);
+  const accentKey = selected?.accentKey || (selected ? RarityAccents[selected.rarity] : undefined);
+  const accent = accentKey ? ElementAccents[accentKey] : undefined;
+  const ownedCount = skins.filter((s) => s.owned).length;
+  const lockedCount = skins.length - ownedCount;
+  const rarityLabelMap = {
+    common: "común",
+    rare: "rara",
+    epic: "épica",
+    legendary: "legendaria",
+  };
+
+  if (!mounted) return null;
+
+  const translateY = sheetAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [sheetHeight.current || 0, 0],
+  });
+
+  return (
+    <View
+      style={StyleSheet.absoluteFill}
+      pointerEvents="box-none"
+      accessible
+      accessibilityViewIsModal
+    >
+      {/* [MB] Backdrop con fade */}
+      <AnimatedPressable
+        accessibilityRole="button"
+        accessibilityLabel="Cerrar inventario"
+        onPress={onClose}
+        style={[styles.backdrop, { opacity: backdropAnim }]}
+      />
+      <Animated.View
+        onLayout={(e) => (sheetHeight.current = e.nativeEvent.layout.height)}
+        style={[
+          styles.sheet,
+          { transform: [{ translateY }] },
+        ]}
+      >
+        <View style={styles.header} accessibilityRole="header">
+          <Text style={styles.title}>Inventario</Text>
+          <Text style={styles.subtitle}>{`Propias ${ownedCount} • Bloqueadas ${lockedCount}`}</Text>
+        </View>
+        <View style={styles.preview}>
+          <PlantHero size="md" skinAccent={accent} />
+          {selected && (
+            <Text style={styles.previewLabel}>{`${selected.name} • ${rarityLabelMap[selected.rarity]}`}</Text>
+          )}
+        </View>
+        <FlatList
+          data={skins}
+          keyExtractor={(item) => item.id}
+          numColumns={numColumns}
+          contentContainerStyle={styles.grid}
+          renderItem={({ item }) => (
+            <View style={{ flex: 1 / numColumns, padding: Spacing.small }}>
+              <PotSkinCard
+                item={item}
+                onPress={(id) => onSelect && onSelect(id)}
+                onEquip={(id) => onEquip && onEquip(id)}
+                onBuy={(id) => onBuy && onBuy(id)}
+              />
+            </View>
+          )}
+        />
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: Colors.overlay,
+  },
+  sheet: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: Colors.surfaceElevated,
+    borderTopLeftRadius: Radii.xl,
+    borderTopRightRadius: Radii.xl,
+    paddingBottom: Spacing.large,
+    paddingTop: Spacing.base,
+    ...Elevation.card,
+  },
+  header: {
+    alignItems: "center",
+    marginBottom: Spacing.base,
+  },
+  title: {
+    ...Typography.title,
+    color: Colors.text,
+  },
+  subtitle: {
+    ...Typography.caption,
+    color: Colors.text,
+    opacity: Opacity.muted,
+    marginTop: Spacing.tiny,
+  },
+  preview: {
+    alignItems: "center",
+    marginBottom: Spacing.base,
+  },
+  previewLabel: {
+    ...Typography.body,
+    color: Colors.text,
+    marginTop: Spacing.small,
+  },
+  grid: {
+    paddingHorizontal: Spacing.base,
+    paddingBottom: Spacing.large,
+  },
+});
+

--- a/src/components/plant/PlantHero.js
+++ b/src/components/plant/PlantHero.js
@@ -1,8 +1,8 @@
 // [MB] Módulo: Planta / Sección: Hero animado
 // Afecta: PlantScreen (demo inicial)
 // Propósito: muestra la planta con aura, glow y animación de respirar
-// Puntos de edición futura: estilos y tamaños adaptables
-// Autor: Codex - Fecha: 2025-08-15
+// Puntos de edición futura: estilos, tamaños y assets de maceta
+// Autor: Codex - Fecha: 2025-08-16
 
 import React, { useEffect, useRef } from "react";
 import { View, Text, Image, Animated, Easing, StyleSheet } from "react-native";
@@ -20,6 +20,7 @@ export default function PlantHero({
   health,
   mood,
   stage,
+  skinAccent,
   style,
 }) {
   const anim = useRef(new Animated.Value(0)).current;
@@ -109,6 +110,22 @@ export default function PlantHero({
         ) : (
           <Text style={{ fontSize: baseSize * 0.6 }}>🌱</Text>
         )}
+        {skinAccent && (
+          <View
+            pointerEvents="none"
+            style={[
+              styles.pot,
+              {
+                backgroundColor: skinAccent,
+                width: baseSize * 0.6,
+                height: baseSize * 0.25,
+                borderRadius: (baseSize * 0.6) / 2,
+                left: (baseSize - baseSize * 0.6) / 2,
+                bottom: Spacing.small,
+              },
+            ]}
+          />
+        )}
         <View
           pointerEvents="none"
           style={[
@@ -145,6 +162,9 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 0 },
     shadowOpacity: 0.3,
     shadowRadius: Spacing.small,
+  },
+  pot: {
+    position: "absolute",
   },
 });
 

--- a/src/components/plant/PotSkinCard.js
+++ b/src/components/plant/PotSkinCard.js
@@ -1,0 +1,248 @@
+// [MB] Módulo: Planta / Sección: Inventario de macetas
+// Afecta: PlantScreen (sheet de inventario)
+// Propósito: tarjeta de skin con estados y acciones
+// Puntos de edición futura: mover estilos a archivo separado o integrar economía real
+// Autor: Codex - Fecha: 2025-08-16
+
+import React, { useRef } from "react";
+import {
+  Animated,
+  Pressable,
+  Text,
+  View,
+  StyleSheet,
+} from "react-native";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Typography,
+  Elevation,
+  Opacity,
+} from "../../theme";
+
+// [MB] Acentos por rareza o clave explícita
+const ElementAccents = {
+  neutral: Colors.surfaceAlt,
+  water: Colors.elementWater,
+  spirit: Colors.secondaryFantasy,
+  mana: Colors.primaryFantasy,
+};
+
+const RarityAccents = {
+  common: "neutral",
+  rare: "water",
+  epic: "spirit",
+  legendary: "mana",
+};
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+export default function PotSkinCard({ item, onPress, onEquip, onBuy }) {
+  const scale = useRef(new Animated.Value(1)).current;
+  const tooltipOpacity = useRef(new Animated.Value(0)).current;
+  const tooltipTimeout = useRef();
+
+  const accentKey = item.accentKey || RarityAccents[item.rarity];
+  const accent = ElementAccents[accentKey] || Colors.surfaceElevated;
+  const owned = item.owned;
+  const equipped = item.equipped;
+
+  const handlePressIn = () => {
+    Animated.spring(scale, {
+      toValue: 0.98,
+      useNativeDriver: true,
+      speed: 20,
+      bounciness: 6,
+    }).start();
+  };
+  const handlePressOut = () => {
+    Animated.spring(scale, {
+      toValue: 1,
+      useNativeDriver: true,
+      speed: 20,
+      bounciness: 6,
+    }).start();
+  };
+
+  const handleBuy = () => {
+    onBuy && onBuy(item.id);
+    Animated.timing(tooltipOpacity, {
+      toValue: 1,
+      duration: 150,
+      useNativeDriver: true,
+    }).start();
+    tooltipTimeout.current && clearTimeout(tooltipTimeout.current);
+    tooltipTimeout.current = setTimeout(() => {
+      Animated.timing(tooltipOpacity, {
+        toValue: 0,
+        duration: 150,
+        useNativeDriver: true,
+      }).start();
+    }, 1000);
+  };
+
+  const accessibilityLabel = `Skin ${item.name}, ${
+    owned ? "propia" : "bloqueada"
+  }, rareza ${item.rarity}${equipped ? ", equipada" : ""}`;
+
+  const costLabel =
+    item.cost && `${item.cost.amount} ${item.cost.currency === "coins" ? "Monedas" : "Diamantes"}`;
+
+  return (
+    <AnimatedPressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityHint="Toca para previsualizar. Botón Equipar/Comprar al final de la tarjeta."
+      onPress={() => onPress && onPress(item.id)}
+      onPressIn={handlePressIn}
+      onPressOut={handlePressOut}
+      style={[
+        styles.card,
+        { borderColor: accent, transform: [{ scale }] },
+        !owned && { opacity: Opacity.muted },
+      ]}
+    >
+      <View style={styles.thumbWrapper}>
+        {item.thumb ? (
+          typeof item.thumb === "string" ? (
+            <Text style={styles.thumbText}>{item.thumb}</Text>
+          ) : (
+            <View>{/* imagen personalizada */}</View>
+          )
+        ) : (
+          <Text style={styles.thumbText}>🎍</Text>
+        )}
+        {equipped ? (
+          <View style={[styles.badge, { backgroundColor: accent }]}> 
+            <Text style={styles.badgeText}>Equipado</Text>
+          </View>
+        ) : owned ? (
+          <View style={[styles.badge, { backgroundColor: accent, opacity: 0.8 }]}> 
+            <Text style={styles.badgeText}>Propio</Text>
+          </View>
+        ) : (
+          <View style={[styles.badge, { backgroundColor: Colors.overlay }]}> 
+            <Text style={styles.badgeText}>🔒</Text>
+          </View>
+        )}
+      </View>
+      <Text numberOfLines={1} style={styles.name}>
+        {item.name}
+      </Text>
+      {owned && !equipped && (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={`Equipar ${item.name}`}
+          onPress={() => onEquip && onEquip(item.id)}
+          style={[styles.actionButton, { backgroundColor: accent }]}
+        >
+          <Text style={styles.actionText}>Equipar</Text>
+        </Pressable>
+      )}
+      {equipped && (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={`Quitar ${item.name}`}
+          onPress={() => onEquip && onEquip(undefined)}
+          style={[styles.actionButton, { backgroundColor: Colors.surfaceAlt }]}
+        >
+          <Text style={styles.actionText}>Quitar</Text>
+        </Pressable>
+      )}
+      {!owned && (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={`Comprar ${item.name}`}
+          onPress={handleBuy}
+          style={[styles.actionButton, { backgroundColor: accent }]}
+        >
+          <Text style={styles.actionText}>Comprar</Text>
+        </Pressable>
+      )}
+      {!owned && costLabel && (
+        <Text style={styles.cost}>{costLabel}</Text>
+      )}
+      <Animated.View
+        pointerEvents="none"
+        accessible
+        accessibilityLiveRegion="polite"
+        accessibilityLabel="Compra no implementada (UI)"
+        style={[styles.tooltip, { opacity: tooltipOpacity }]}
+      >
+        <Text style={styles.tooltipText}>Compra no implementada (UI)</Text>
+      </Animated.View>
+    </AnimatedPressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flex: 1,
+    alignItems: "center",
+    padding: Spacing.small,
+    borderRadius: Radii.lg,
+    borderWidth: 2,
+    backgroundColor: Colors.surface,
+    ...Elevation.card,
+  },
+  thumbWrapper: {
+    width: "100%",
+    alignItems: "center",
+    marginBottom: Spacing.small,
+    position: "relative",
+  },
+  thumbText: {
+    fontSize: Typography.h1.fontSize,
+  },
+  name: {
+    ...Typography.body,
+    color: Colors.text,
+    marginBottom: Spacing.small,
+  },
+  badge: {
+    position: "absolute",
+    top: 0,
+    right: 0,
+    paddingHorizontal: Spacing.tiny,
+    paddingVertical: 2,
+    borderRadius: Radii.pill,
+  },
+  badgeText: {
+    ...Typography.caption,
+    color: Colors.textInverse,
+  },
+  actionButton: {
+    marginTop: Spacing.tiny,
+    paddingVertical: Spacing.tiny,
+    paddingHorizontal: Spacing.small,
+    borderRadius: Radii.pill,
+  },
+  actionText: {
+    ...Typography.caption,
+    color: Colors.textInverse,
+  },
+  cost: {
+    ...Typography.caption,
+    color: Colors.textMuted,
+    marginTop: Spacing.tiny,
+  },
+  tooltip: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    alignItems: "center",
+    transform: [{ translateY: 0 }],
+  },
+  tooltipText: {
+    ...Typography.caption,
+    color: Colors.text,
+    backgroundColor: Colors.surfaceElevated,
+    paddingHorizontal: Spacing.small,
+    paddingVertical: Spacing.tiny,
+    borderRadius: Radii.sm,
+    ...Elevation.raised,
+  },
+});
+

--- a/src/screens/PlantScreen.js
+++ b/src/screens/PlantScreen.js
@@ -4,22 +4,46 @@
 // Puntos de edición futura: añadir header real y contenidos extra
 // Autor: Codex - Fecha: 2025-08-16
 
-import React from "react";
+import React, { useState } from "react";
 import { SafeAreaView, ScrollView, StyleSheet } from "react-native";
 import PlantHero from "../components/plant/PlantHero";
 import CareMetrics from "../components/plant/CareMetrics";
 import QuickActions from "../components/plant/QuickActions";
 import GrowthProgress from "../components/plant/GrowthProgress";
 import BuffsBar from "../components/plant/BuffsBar";
+import InventorySheet from "../components/plant/InventorySheet";
 import { Colors, Spacing } from "../theme";
 
+const ElementAccents = {
+  neutral: Colors.surfaceAlt,
+  water: Colors.elementWater,
+  spirit: Colors.secondaryFantasy,
+  mana: Colors.primaryFantasy,
+};
+
 export default function PlantScreen() {
+  const [invOpen, setInvOpen] = useState(false);
+  const [equippedSkinId, setEquippedSkinId] = useState();
+  const [selectedSkinId, setSelectedSkinId] = useState();
+  const [skins, setSkins] = useState([
+    { id: "s1", name: "Maceta Rústica", rarity: "common", owned: true, equipped: true, accentKey: "neutral", thumb: "🎍" },
+    { id: "s2", name: "Arcana Azul", rarity: "rare", owned: true, accentKey: "water", thumb: "🔵" },
+    { id: "s3", name: "Esencia Etérea", rarity: "epic", owned: false, accentKey: "spirit", cost: { currency: "diamonds", amount: 120 }, thumb: "💠" },
+    { id: "s4", name: "Corazón de Maná", rarity: "legendary", owned: false, accentKey: "mana", cost: { currency: "coins", amount: 2400 }, thumb: "💎" },
+  ]);
+
+  const equippedSkin = skins.find((s) => s.id === equippedSkinId);
+  const skinAccent = equippedSkin ? ElementAccents[equippedSkin.accentKey] : undefined;
+
   return (
     <SafeAreaView style={styles.safeArea}>
       {/* [MB] Contenido scrollable para evitar notch y reservar espacio para FAB */}
-      <ScrollView contentContainerStyle={styles.content}>
-        {/* [MB] Hero de planta */}
-        <PlantHero health={0.95} mood="floreciente" stage="brote" />
+      <ScrollView
+        contentContainerStyle={styles.content}
+        importantForAccessibility={invOpen ? "no-hide-descendants" : "auto"}
+      >
+        {/* [MB] Hero de planta con overlay de maceta */}
+        <PlantHero health={0.95} mood="floreciente" stage="brote" skinAccent={skinAccent} />
         {/* [MB] Métricas de cuidado */}
         <CareMetrics
           water={0.62}
@@ -35,7 +59,14 @@ export default function PlantScreen() {
           canClean
           canMeditate
           cooldowns={{ water: 0, feed: 0, clean: 0, meditate: 0 }}
-          onAction={(key) => console.log("[MB] acción", key)}
+          onAction={(key) => {
+            if (key === "clean") {
+              setSelectedSkinId(equippedSkinId);
+              setInvOpen(true);
+            } else {
+              console.log("[MB] acción", key);
+            }
+          }}
         />
         {/* [MB] Progreso de crecimiento */}
         <GrowthProgress
@@ -59,6 +90,20 @@ export default function PlantScreen() {
           onExpire={(id) => console.log("[MB] buff expirado:", id)}
         />
       </ScrollView>
+      <InventorySheet
+        visible={invOpen}
+        skins={skins.map((s) => ({ ...s, equipped: s.id === equippedSkinId }))}
+        selectedId={selectedSkinId}
+        equippedId={equippedSkinId}
+        onClose={() => setInvOpen(false)}
+        onSelect={(id) => setSelectedSkinId(id)}
+        onEquip={(id) => {
+          setEquippedSkinId(id);
+          setSkins((prev) => prev.map((s) => ({ ...s, equipped: s.id === id })));
+          setInvOpen(false);
+        }}
+        onBuy={(id) => console.log("[MB] compra mock", id)}
+      />
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
## Summary
- add pot skin card with rarity accents, equip/buy actions and tooltip
- introduce inventory bottom sheet with live PlantHero preview and grid
- wire PlantScreen to open inventory from QuickActions and apply selected skin

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fe9919140832791a94e0ca79be521