### PR TITLE
[MB] TaskFilterBar: animated chip behind active tab

### DIFF
--- a/src/components/TaskFilterBar/TaskFilterBar.styles.js
+++ b/src/components/TaskFilterBar/TaskFilterBar.styles.js
@@ -1,9 +1,9 @@
-// [MB] TaskFilterBar.styles — tabs segmentadas
+// [MB] TaskFilterBar.styles — tabs con chip trasero
 // [MB] Módulo: Tasks / Sección: Barra de filtros
 // Afecta: TaskFilterBar (tabs principales)
-// Propósito: Estilos de control segmentado para estado de tareas
-// Puntos de edición futura: animaciones y accesibilidad
-// Autor: Codex - Fecha: 2025-08-14
+// Propósito: Estilos para chip animado en tabs de estado
+// Puntos de edición futura: mejoras de contraste y foco
+// Autor: Codex - Fecha: 2025-08-22
 
 import { StyleSheet } from "react-native";
 import { Colors, Spacing, Radii } from "../../theme";
@@ -12,38 +12,35 @@ export default StyleSheet.create({
   container: {
     flexDirection: "row",
     gap: Spacing.small,
+    position: "relative",
+    height: Spacing.xlarge + Spacing.tiny,
   },
   button: {
     flex: 1,
-    height: Spacing.xlarge + Spacing.tiny,
     borderRadius: Radii.md,
     alignItems: "center",
     justifyContent: "center",
-    backgroundColor: Colors.surface,
-    position: "relative",
   },
-  buttonActive: {},
-  buttonInactive: {},
+  chip: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    bottom: 0,
+    borderRadius: Radii.md,
+    backgroundColor: Colors.accent,
+    zIndex: -1,
+  },
   tabContent: {
     flexDirection: "row",
     alignItems: "center",
     gap: Spacing.tiny,
-  },
-  underline: {
-    position: "absolute",
-    left: Spacing.small,
-    right: Spacing.small,
-    bottom: 0,
-    height: 2,
-    backgroundColor: Colors.secondary,
-    borderRadius: 1,
   },
   label: {
     fontSize: 14,
     fontWeight: "600",
   },
   labelActive: {
-    color: Colors.text,
+    color: Colors.onAccent,
   },
   labelInactive: {
     color: Colors.textMuted,


### PR DESCRIPTION
## Summary
- animate accent chip behind active task filter tab
- scale tabs on press and adjust text/icon colors for accessibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fed29631883278e03dc5b50335234