### PR TITLE
feat(plant): header compacto con nombre editable, chips de salud/ánimo y economía integrada

### DIFF
--- a/src/components/plant/HealthChip.js
+++ b/src/components/plant/HealthChip.js
@@ -1,0 +1,78 @@
+// [MB] Módulo: Planta / Sección: Header compacto
+// Afecta: PlantScreen (cabecera con salud)
+// Propósito: chip de salud derivada de agua/luz/nutrientes
+// Puntos de edición futura: estados de color o layout
+// Autor: Codex - Fecha: 2025-08-16
+
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Typography,
+  Elevation,
+  Opacity,
+} from "../../theme";
+
+const ElementAccents = {
+  health: Colors.success,
+};
+
+const LOW = 0.35;
+const HIGH = 0.8;
+
+export default function HealthChip({ value }) {
+  const v = clamp01(value);
+  const pct = Math.round(v * 100);
+  const state = getState(v);
+  const chipOpacity = state === "LOW" ? 0.6 : state === "OK" ? 0.85 : 1;
+
+  return (
+    <View
+      accessibilityRole="text"
+      accessibilityLabel={`Salud ${pct} %, estado ${state}`}
+      style={[styles.chip, { backgroundColor: ElementAccents.health, opacity: chipOpacity }]}
+    >
+      <Text style={styles.icon}>❤️</Text>
+      <Text style={styles.label}>Salud</Text>
+      <Text style={styles.value}>{pct}%</Text>
+    </View>
+  );
+}
+
+function clamp01(n) {
+  return Math.max(0, Math.min(1, n ?? 0));
+}
+
+function getState(v) {
+  if (v < LOW) return "LOW";
+  if (v <= HIGH) return "OK";
+  return "HIGH";
+}
+
+const styles = StyleSheet.create({
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: Radii.pill,
+    paddingHorizontal: Spacing.base,
+    paddingVertical: Spacing.small,
+    ...Elevation.raised,
+  },
+  icon: {
+    marginRight: Spacing.small,
+  },
+  label: {
+    ...Typography.caption,
+    color: Colors.textInverse,
+    opacity: Opacity.muted,
+    marginRight: Spacing.small,
+  },
+  value: {
+    ...Typography.body,
+    fontWeight: "700",
+    color: Colors.textInverse,
+  },
+});
+

--- a/src/components/plant/MoodChip.js
+++ b/src/components/plant/MoodChip.js
@@ -1,0 +1,87 @@
+// [MB] Módulo: Planta / Sección: Header compacto
+// Afecta: PlantScreen (cabecera con ánimo)
+// Propósito: chip de ánimo opcional
+// Puntos de edición futura: estados de color o layout
+// Autor: Codex - Fecha: 2025-08-16
+
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Typography,
+  Elevation,
+  Opacity,
+} from "../../theme";
+
+const ElementAccents = {
+  spirit: Colors.secondaryFantasy,
+};
+
+const LOW = 0.35;
+const HIGH = 0.8;
+
+export default function MoodChip({ value }) {
+  const hasValue = typeof value === "number";
+  const v = clamp01(value);
+  const pct = hasValue ? Math.round(v * 100) : null;
+  const state = hasValue ? getState(v) : null;
+  const chipOpacity = !hasValue
+    ? Opacity.muted
+    : state === "LOW"
+    ? 0.6
+    : state === "OK"
+    ? 0.85
+    : 1;
+
+  return (
+    <View
+      accessibilityRole="text"
+      accessibilityLabel={
+        hasValue ? `Ánimo ${pct} %, estado ${state}` : "Ánimo sin datos"
+      }
+      style={[styles.chip, { backgroundColor: ElementAccents.spirit, opacity: chipOpacity }]}
+    >
+      <Text style={styles.icon}>🧘</Text>
+      <Text style={styles.label}>Ánimo</Text>
+      <Text style={styles.value}>{hasValue ? `${pct}%` : "—"}</Text>
+    </View>
+  );
+}
+
+function clamp01(n) {
+  return Math.max(0, Math.min(1, n ?? 0));
+}
+
+function getState(v) {
+  if (v < LOW) return "LOW";
+  if (v <= HIGH) return "OK";
+  return "HIGH";
+}
+
+const styles = StyleSheet.create({
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: Radii.pill,
+    paddingHorizontal: Spacing.base,
+    paddingVertical: Spacing.small,
+    ...Elevation.raised,
+  },
+  icon: {
+    marginRight: Spacing.small,
+  },
+  label: {
+    ...Typography.caption,
+    color: Colors.textInverse,
+    opacity: Opacity.muted,
+    marginRight: Spacing.small,
+  },
+  value: {
+    ...Typography.body,
+    fontWeight: "700",
+    color: Colors.textInverse,
+  },
+});
+

--- a/src/components/plant/PlantHeader.js
+++ b/src/components/plant/PlantHeader.js
@@ -1,0 +1,208 @@
+// [MB] Módulo: Planta / Sección: Header compacto
+// Afecta: PlantScreen (cabecera principal)
+// Propósito: agrupar nombre editable, salud/ánimo y economía
+// Puntos de edición futura: mover cálculo de salud o estilos a .styles.js
+// Autor: Codex - Fecha: 2025-08-16
+
+import React, { useState, useRef } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  StyleSheet,
+  Animated,
+  AccessibilityInfo,
+} from "react-native";
+import ResourceCapsules from "../economy/ResourceCapsules";
+import StreakChip from "../economy/StreakChip";
+import HealthChip from "./HealthChip";
+import MoodChip from "./MoodChip";
+import {
+  Colors,
+  Spacing,
+  Radii,
+  Typography,
+  Elevation,
+} from "../../theme";
+
+// [MB] Helpers de salud y estados
+const clamp01 = (n) => Math.max(0, Math.min(1, n ?? 0));
+const calcHealth = (w, l, n) => {
+  const vals = [w, l, n].map(clamp01);
+  return (vals[0] + vals[1] + vals[2]) / 3;
+};
+
+export default function PlantHeader({
+  name,
+  onRename,
+  water,
+  light,
+  nutrients,
+  mood,
+  mana,
+  coins,
+  gems,
+  streakDays,
+  txn,
+  insufficient,
+}) {
+  const [isEditing, setIsEditing] = useState(false); // [MB] Control de modo edición
+  const [draftName, setDraftName] = useState(name);
+  const scale = useRef(new Animated.Value(1)).current; // [MB] animación al guardar
+
+  const health = calcHealth(water, light, nutrients); // [MB] salud derivada de métricas
+
+  const handleStartEdit = () => {
+    setDraftName(name);
+    setIsEditing(true);
+  };
+
+  const handleCancel = () => {
+    setDraftName(name);
+    setIsEditing(false);
+  };
+
+  const handleSubmit = () => {
+    const next = draftName.trim().slice(0, 40);
+    if (!next) {
+      handleCancel();
+      return;
+    }
+    if (next !== name) {
+      onRename && onRename(next);
+      AccessibilityInfo.announceForAccessibility?.(
+        "Nombre de planta actualizado a " + next
+      );
+    }
+    setIsEditing(false);
+    Animated.sequence([
+      Animated.timing(scale, { toValue: 1.02, duration: 70, useNativeDriver: true }),
+      Animated.timing(scale, { toValue: 1, duration: 70, useNativeDriver: true }),
+    ]).start();
+  };
+
+  return (
+    <View
+      style={styles.container}
+      accessibilityRole="header"
+      accessibilityLabel="Cabecera de la planta"
+    >
+      <View style={styles.topRow}>
+        <View style={styles.nameWrap}>
+          {isEditing ? (
+            <TextInput
+              value={draftName}
+              onChangeText={setDraftName}
+              maxLength={40}
+              style={styles.nameInput}
+              autoFocus
+              selectTextOnFocus
+              onSubmitEditing={handleSubmit}
+              onBlur={handleSubmit}
+              onKeyPress={(e) => {
+                if (e.nativeEvent.key === "Escape") {
+                  handleCancel();
+                }
+              }}
+              accessibilityLabel="Nombre de la planta"
+            />
+          ) : (
+            <>
+              <Animated.Text
+                style={[styles.name, { transform: [{ scale }] }]}
+                numberOfLines={2}
+              >
+                {name}
+              </Animated.Text>
+              <Pressable
+                onPress={handleStartEdit}
+                hitSlop={Spacing.large}
+                accessibilityRole="button"
+                accessibilityLabel="Editar nombre de la planta"
+                style={styles.editBtn}
+              >
+                <Text style={styles.editIcon}>✏️</Text>
+              </Pressable>
+            </>
+          )}
+        </View>
+        <View style={styles.chips}>
+          <HealthChip value={health} />
+          <View style={{ width: Spacing.base }} />
+          <MoodChip value={mood} />
+        </View>
+      </View>
+      <View style={styles.bottomRow}>
+        {/* [MB] Economía reubicada dentro del header */}
+        <View style={styles.capsules}>
+          <ResourceCapsules
+            mana={mana}
+            coins={coins}
+            gems={gems}
+            txn={txn}
+            insufficient={insufficient}
+          />
+        </View>
+        <View style={styles.streakItem}>
+          <StreakChip days={streakDays} />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: Colors.surfaceElevated,
+    borderRadius: Radii.lg,
+    padding: Spacing.large,
+    ...Elevation.card,
+  },
+  topRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+  },
+  nameWrap: {
+    flexDirection: "row",
+    alignItems: "center",
+    flex: 1,
+    marginRight: Spacing.base,
+  },
+  name: {
+    ...Typography.h2,
+    color: Colors.text,
+    flexShrink: 1,
+  },
+  nameInput: {
+    ...Typography.h2,
+    color: Colors.text,
+    flex: 1,
+  },
+  editBtn: {
+    marginLeft: Spacing.small,
+  },
+  editIcon: {
+    fontSize: Typography.body.fontSize,
+    color: Colors.text,
+  },
+  chips: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  bottomRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "center",
+    marginTop: Spacing.base,
+  },
+  capsules: {
+    marginRight: Spacing.base,
+    marginBottom: Spacing.small,
+  },
+  streakItem: {
+    marginBottom: Spacing.small,
+  },
+});
+

--- a/src/screens/PlantScreen.js
+++ b/src/screens/PlantScreen.js
@@ -5,15 +5,14 @@
 // Autor: Codex - Fecha: 2025-08-16
 
 import React, { useState } from "react";
-import { SafeAreaView, ScrollView, StyleSheet, AccessibilityInfo, View } from "react-native";
+import { SafeAreaView, ScrollView, StyleSheet, AccessibilityInfo } from "react-native";
 import PlantHero from "../components/plant/PlantHero";
 import CareMetrics from "../components/plant/CareMetrics";
 import QuickActions from "../components/plant/QuickActions";
 import GrowthProgress from "../components/plant/GrowthProgress";
 import BuffsBar from "../components/plant/BuffsBar";
 import InventorySheet from "../components/plant/InventorySheet";
-import ResourceCapsules from "../components/economy/ResourceCapsules";
-import StreakChip from "../components/economy/StreakChip";
+import PlantHeader from "../components/plant/PlantHeader";
 import { Colors, Spacing } from "../theme";
 
 const ElementAccents = {
@@ -24,6 +23,7 @@ const ElementAccents = {
 };
 
 export default function PlantScreen() {
+  const [plantName, setPlantName] = useState("Mi Planta");
   const [invOpen, setInvOpen] = useState(false);
   const [equippedSkinId, setEquippedSkinId] = useState();
   const [selectedSkinId, setSelectedSkinId] = useState();
@@ -93,20 +93,20 @@ export default function PlantScreen() {
         contentContainerStyle={styles.content}
         importantForAccessibility={invOpen ? "no-hide-descendants" : "auto"}
       >
-        <View style={styles.economyRow}>
-          <View style={styles.capsules}>
-            <ResourceCapsules
-              mana={economy.mana}
-              coins={economy.coins}
-              gems={economy.gems}
-              txn={txn}
-              insufficient={insufficient}
-            />
-          </View>
-          <View style={styles.streakItem}>
-            <StreakChip days={streakDays} />
-          </View>
-        </View>
+        <PlantHeader
+          name={plantName}
+          onRename={(next) => setPlantName(next)}
+          water={0.62}
+          light={0.48}
+          nutrients={0.3}
+          mood={0.95}
+          mana={economy.mana}
+          coins={economy.coins}
+          gems={economy.gems}
+          streakDays={streakDays}
+          txn={txn}
+          insufficient={insufficient}
+        />
         {/* [MB] Hero de planta con overlay de maceta */}
         <PlantHero health={0.95} mood="floreciente" stage="brote" skinAccent={skinAccent} />
         {/* [MB] Métricas de cuidado */}
@@ -182,20 +182,6 @@ const styles = StyleSheet.create({
     padding: Spacing.large,
     paddingBottom: Spacing.large * 3,
     alignItems: "center",
-  },
-  economyRow: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    alignItems: "center",
-    alignSelf: "stretch",
-    marginBottom: Spacing.large,
-  },
-  capsules: {
-    marginRight: Spacing.base,
-    marginBottom: Spacing.small,
-  },
-  streakItem: {
-    marginBottom: Spacing.small,
   },
 });
 


### PR DESCRIPTION
## Summary
- Add compact PlantHeader with inline renaming, health/mood chips, and embedded economy
- Introduce reusable HealthChip and MoodChip components
- Update PlantScreen to render new header and pass economy/metric props

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ff0cee9a083279f30e7ad978050f4