### PR TITLE
[MB] Fix TaskFilterBar chip layering and badge

### DIFF
--- a/src/components/TaskFilterBar/TaskFilterBar.js
+++ b/src/components/TaskFilterBar/TaskFilterBar.js
@@ -3,10 +3,10 @@
 // Afecta: TaskFilterBar (tabs principales)
 // Propósito: Tabs accesibles alineadas al tema con chip trasero
 // Puntos de edición futura: estilos de enfoque y más tabs
-// Autor: Codex - Fecha: 2025-08-22
+// Autor: Codex - Fecha: 2025-08-16
 
 import React, { useRef, useState, useEffect } from "react";
-import { View, Text, Animated, Pressable } from "react-native";
+import { View, Text, Animated, Pressable, Easing } from "react-native";
 import { FontAwesome5 } from "@expo/vector-icons";
 import styles from "./TaskFilterBar.styles";
 import { Colors, Spacing } from "../../theme";
@@ -16,7 +16,10 @@ const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 export default function TaskFilterBar({ filters, active, onSelect }) {
   const [width, setWidth] = useState(0);
   const gap = Spacing.small;
-  const tabWidth = (width - gap * (filters.length - 1)) / filters.length;
+  const padding = Spacing.small;
+  const tabWidth = width
+    ? (width - padding * 2 - gap * (filters.length - 1)) / filters.length
+    : 0;
   const translateX = useRef(new Animated.Value(0)).current;
   const chipOpacity = useRef(new Animated.Value(0)).current;
   const scales = useRef(filters.map(() => new Animated.Value(1))).current;
@@ -28,11 +31,13 @@ export default function TaskFilterBar({ filters, active, onSelect }) {
       Animated.timing(translateX, {
         toValue: index * (tabWidth + gap),
         duration: 180,
+        easing: Easing.out(Easing.ease),
         useNativeDriver: true,
       }),
       Animated.timing(chipOpacity, {
         toValue: 1,
         duration: 150,
+        easing: Easing.out(Easing.ease),
         useNativeDriver: true,
       }),
     ]).start();
@@ -58,6 +63,10 @@ export default function TaskFilterBar({ filters, active, onSelect }) {
       {filters.map((f, index) => {
         const isActive = active === f.key;
         const scale = scales[index];
+        const activeColor = Colors.textOnAccent || Colors.onAccent || Colors.text;
+        const inactiveColor = Colors.textMuted;
+        const color = isActive ? activeColor : inactiveColor;
+        const accLabel = `${f.label}${f.count ? ` (${f.count})` : ""}`;
         return (
           <AnimatedPressable
             key={f.key}
@@ -79,21 +88,19 @@ export default function TaskFilterBar({ filters, active, onSelect }) {
             }
             accessibilityRole="tab"
             accessibilityState={{ selected: isActive }}
+            accessibilityLabel={accLabel}
           >
             <View style={styles.tabContent}>
               {f.icon && (
-                <FontAwesome5
-                  name={f.icon}
-                  size={14}
-                  color={isActive ? Colors.onAccent : Colors.textMuted}
-                />
+                <FontAwesome5 name={f.icon} size={14} color={color} />
               )}
-              <Text
-                style={[styles.label, isActive ? styles.labelActive : styles.labelInactive]}
-              >
-                {f.label}
-              </Text>
+              <Text style={[styles.label, { color }]}>{f.label}</Text>
             </View>
+            {f.count > 0 && (
+              <View style={styles.badge} pointerEvents="none">
+                <Text style={styles.badgeText}>{f.count}</Text>
+              </View>
+            )}
           </AnimatedPressable>
         );
       })}

--- a/src/components/TaskFilterBar/TaskFilterBar.styles.js
+++ b/src/components/TaskFilterBar/TaskFilterBar.styles.js
@@ -3,10 +3,10 @@
 // Afecta: TaskFilterBar (tabs principales)
 // Propósito: Estilos para chip animado en tabs de estado
 // Puntos de edición futura: mejoras de contraste y foco
-// Autor: Codex - Fecha: 2025-08-22
+// Autor: Codex - Fecha: 2025-08-16
 
 import { StyleSheet } from "react-native";
-import { Colors, Spacing, Radii } from "../../theme";
+import { Colors, Spacing, Radii, Typography } from "../../theme";
 
 export default StyleSheet.create({
   container: {
@@ -14,12 +14,18 @@ export default StyleSheet.create({
     gap: Spacing.small,
     position: "relative",
     height: Spacing.xlarge + Spacing.tiny,
+    paddingHorizontal: Spacing.small,
+    borderRadius: Radii.md,
+    overflow: "hidden",
   },
   button: {
     flex: 1,
     borderRadius: Radii.md,
     alignItems: "center",
     justifyContent: "center",
+    position: "relative",
+    zIndex: 1,
+    elevation: 1,
   },
   chip: {
     position: "absolute",
@@ -28,21 +34,34 @@ export default StyleSheet.create({
     bottom: 0,
     borderRadius: Radii.md,
     backgroundColor: Colors.accent,
-    zIndex: -1,
+    zIndex: 0,
+    elevation: 0,
   },
   tabContent: {
     flexDirection: "row",
     alignItems: "center",
     gap: Spacing.tiny,
+    zIndex: 1,
+    elevation: 1,
   },
   label: {
-    fontSize: 14,
+    ...Typography.body,
     fontWeight: "600",
   },
-  labelActive: {
-    color: Colors.onAccent,
+  badge: {
+    position: "absolute",
+    top: -Spacing.tiny,
+    right: -Spacing.tiny * 1.5,
+    backgroundColor: Colors.attention || Colors.warning || Colors.accent,
+    borderRadius: Radii.pill,
+    paddingHorizontal: Spacing.tiny,
+    paddingVertical: Spacing.tiny / 2,
+    zIndex: 2,
+    pointerEvents: "none",
   },
-  labelInactive: {
-    color: Colors.textMuted,
+  badgeText: {
+    ...Typography.caption,
+    color: Colors.onAttention || Colors.onAccent || Colors.text,
+    fontWeight: "700",
   },
 });


### PR DESCRIPTION
## Summary
- keep animated chip behind active tab with proper z-index and measurement
- color icons and labels via tokens and animate chip easing
- add count badge with accessibility labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ff1c132208327837d9d559f42a031