### PR TITLE
refactor: replace HomeHeader icons with text labels

### DIFF
--- a/src/components/home/HomeHeader.js
+++ b/src/components/home/HomeHeader.js
@@ -20,12 +20,11 @@ import {
   findNodeHandle,
   Platform,
 } from "react-native";
-import { MaterialCommunityIcons as Icon } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
 import { useNavigation } from "@react-navigation/native";
 
 import styles from "./HomeHeader.styles";
-import { Colors, Gradients, Spacing } from "../../theme";
+import { Gradients, Spacing } from "../../theme";
 import {
   useAppState,
   useWallet,
@@ -40,11 +39,6 @@ const chipHitSlop = {
   right: Spacing.small,
 };
 
-const ICON_SIZE = 18; // chips de 30px alto
-// Fallback to text color if icon token is missing
-const iconColorSurface = Colors?.icon ?? Colors.text;
-
-const iconColorAccent = Colors.onAccent;
 
 function HomeHeader(
   {
@@ -117,48 +111,42 @@ function HomeHeader(
   const chipConfig = {
     plant: {
       key: "plant",
-      icon: "leaf",
-      label: plantState || "--",
+      label: plantState || "Floreciendo",
       title: "Planta",
-      desc: `Estado actual: ${plantState || "--"}.`,
+      desc: `Estado actual: ${plantState || "Floreciendo"}.`,
       a11y: "Estado de planta",
     },
     mana: {
       key: "mana",
-      icon: "water",
-      label: String(mana),
+      label: "Maná",
       title: "Maná",
       desc: `Tienes ${mana} de maná disponible.`,
       a11y: "Maná",
     },
     coins: {
       key: "coins",
-      icon: "currency-usd",
-      label: String(coin),
+      label: "Monedas",
       title: "Monedas",
       desc: `Tienes ${coin} monedas.`,
       a11y: "Monedas",
     },
     diamonds: {
       key: "diamonds",
-      icon: "diamond-stone",
-      label: String(gem),
+      label: "Diamantes",
       title: "Diamantes",
       desc: `Tienes ${gem} diamantes.`,
       a11y: "Diamantes",
     },
     streak: {
       key: "streak",
-      icon: "fire",
-      label: String(streak),
+      label: "Racha",
       title: "Racha",
       desc: `Racha activa de ${streak} días.`,
       a11y: "Racha activa",
     },
     buffs: {
       key: "buffs",
-      icon: "flask-outline",
-      label: String(buffs.length),
+      label: "Buffs",
       title: "Buffs",
       desc: buffs.length
         ? `${buffs.length} buffs activos.`
@@ -167,8 +155,7 @@ function HomeHeader(
     },
     rewards: {
       key: "rewards",
-      icon: "gift",
-      label: "Ver",
+      label: "Recompensas",
       title: "Recompensas",
       desc: "Explora recompensas disponibles.",
       a11y: "Recompensas",
@@ -237,12 +224,6 @@ function HomeHeader(
             hitSlop={chipHitSlop}
           >
             <View style={styles.chipContent}>
-              <Icon
-                name={chipConfig.plant.icon}
-                size={ICON_SIZE}
-                color={iconColorSurface}
-                style={styles.icon}
-              />
               <Text
                 style={styles.chipText}
                 numberOfLines={1}
@@ -255,16 +236,11 @@ function HomeHeader(
         </View>
         <Pressable
           onPress={onPressNotifications}
-          style={styles.iconButton}
+          style={styles.notificationsButton}
           accessibilityRole="button"
           accessibilityLabel="Abrir notificaciones"
         >
-          <Icon
-            name="bell-outline"
-            size={ICON_SIZE}
-            color={iconColorSurface}
-            style={styles.icon}
-          />
+          <Text style={styles.notificationsText}>Notificaciones</Text>
         </Pressable>
       </View>
 
@@ -284,22 +260,16 @@ function HomeHeader(
                 }
                 hitSlop={chipHitSlop}
               >
-                <View style={styles.chipContent}>
-                  <Icon
-                    name={c.icon}
-                    size={ICON_SIZE}
-                    color={c.accent ? iconColorAccent : iconColorSurface}
-                    style={styles.icon}
-                  />
-                  <Text
-                    style={c.accent ? styles.chipTextOnAccent : styles.chipText}
-                    numberOfLines={1}
-                    ellipsizeMode="tail"
-                  >
-                    {c.label}
-                  </Text>
-                </View>
-              </Pressable>
+            <View style={styles.chipContent}>
+              <Text
+                style={c.accent ? styles.chipTextOnAccent : styles.chipText}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
+                {c.label}
+              </Text>
+            </View>
+          </Pressable>
             );
           })}
         </View>
@@ -344,17 +314,13 @@ function HomeHeader(
           {buffs.map((b) => (
             <View
               key={b.id || b.type}
-              style={styles.buffIcon}
+              style={styles.buffBadge}
               accessibilityRole="text"
               accessibilityLabel={b.type}
             >
-              <Icon
-                name={
-                  b.type === "xp_double" ? "flask-outline" : "auto-fix"
-                }
-                size={16}
-                color={Colors.accent}
-              />
+              <Text style={styles.buffText} numberOfLines={1}>
+                {b.type === "xp_double" ? "XP" : "FX"}
+              </Text>
             </View>
           ))}
         </View>

--- a/src/components/home/HomeHeader.styles.js
+++ b/src/components/home/HomeHeader.styles.js
@@ -34,18 +34,23 @@ export default StyleSheet.create({
   plantChip: {
     backgroundColor: Colors.surface,
     borderRadius: Radii.lg,
-    paddingHorizontal: Spacing.small,
-    paddingVertical: Spacing.tiny,
-    height: Spacing.large + Spacing.tiny,
+    paddingHorizontal: Spacing.base,
+    paddingVertical: Spacing.small,
+    height: 30,
   },
-  iconButton: {
-    padding: Spacing.tiny,
-    height: 28,
-    width: 28,
+  notificationsButton: {
+    backgroundColor: Colors.surface,
+    borderRadius: Radii.lg,
+    paddingHorizontal: Spacing.base,
+    paddingVertical: Spacing.small,
+    height: 30,
     justifyContent: "center",
     alignItems: "center",
-    borderRadius: Radii.md,
-    backgroundColor: Colors.surface,
+  },
+  notificationsText: {
+    ...Typography.body,
+    fontWeight: "600",
+    color: Colors.text,
   },
   chipBlock: {
     marginTop: Spacing.small,
@@ -64,9 +69,9 @@ export default StyleSheet.create({
   chip: {
     backgroundColor: Colors.surface,
     borderRadius: Radii.lg,
-    paddingHorizontal: Spacing.small,
-    paddingVertical: Spacing.tiny,
-    height: Spacing.large + Spacing.tiny,
+    paddingHorizontal: Spacing.base,
+    paddingVertical: Spacing.small,
+    height: 30,
     flexBasis: "31%",
     maxWidth: "31%",
     flexGrow: 0,
@@ -76,20 +81,19 @@ export default StyleSheet.create({
     backgroundColor: Colors.accent,
   },
   chipContent: {
-    flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
-    gap: Spacing.tiny,
     position: "relative",
     zIndex: 2,
   },
-  icon: {},
   chipText: {
     ...Typography.caption,
+    fontWeight: "600",
     color: Colors.text,
   },
   chipTextOnAccent: {
     ...Typography.caption,
+    fontWeight: "600",
     color: Colors.onAccent,
   },
   popoverContainer: {
@@ -144,12 +148,17 @@ export default StyleSheet.create({
     alignItems: "center",
     gap: Spacing.tiny,
   },
-  buffIcon: {
+  buffBadge: {
     height: 28,
     width: 28,
     borderRadius: Radii.md,
     backgroundColor: Colors.surface,
     justifyContent: "center",
     alignItems: "center",
+  },
+  buffText: {
+    ...Typography.caption,
+    fontWeight: "600",
+    color: Colors.accent,
   },
 });


### PR DESCRIPTION
## Summary
- remove vector icon usage from HomeHeader and show text labels for chips and actions
- restyle header and chip layouts for text-only approach

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ff1db69dc8327bb9d802f4686c874