### PR TITLE
refactor(plant): layout por secciones y jerarquía visual (L1) — cards, headers y espaciados tokenizados

### DIFF
--- a/src/components/economy/StreakChip.js
+++ b/src/components/economy/StreakChip.js
@@ -2,7 +2,7 @@
 // Afecta: PlantScreen (encabezado económico)
 // Propósito: chip de racha con animación de pulso
 // Puntos de edición futura: estilos .styles.js o lógica de progreso
-// Autor: Codex - Fecha: 2025-08-16
+// Autor: Codex - Fecha: 2025-08-17
 
 import React, { useEffect, useRef } from "react";
 import { Animated, Text, StyleSheet } from "react-native";
@@ -46,7 +46,7 @@ export default function StreakChip({ days, accentKey }) {
     <Animated.View
       accessibilityRole="text"
       accessibilityLabel={`Racha, ${days} días`}
-      style={[styles.chip, { backgroundColor: accent }]}
+      style={[styles.chip, { borderColor: accent }]}
     >
       <Animated.Text style={[styles.icon, { opacity: flameOpacity }]}>🔥</Animated.Text>
       <Text style={styles.label}>Racha</Text>
@@ -60,23 +60,24 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     borderRadius: Radii.pill,
-    paddingHorizontal: Spacing.base,
-    paddingVertical: Spacing.small,
+    paddingHorizontal: Spacing.small,
+    paddingVertical: Spacing.tiny,
+    backgroundColor: Colors.surfaceAlt,
+    borderWidth: 1,
     ...Elevation.raised,
   },
   icon: {
-    marginRight: Spacing.small,
+    marginRight: Spacing.tiny,
   },
   label: {
     ...Typography.caption,
-    color: Colors.textInverse,
-    opacity: Opacity.muted,
-    marginRight: Spacing.small,
+    color: Colors.textMuted,
+    marginRight: Spacing.tiny,
   },
   value: {
-    ...Typography.body,
+    ...Typography.caption,
     fontWeight: "700",
-    color: Colors.textInverse,
+    color: Colors.text,
   },
 });
 

--- a/src/components/plant/ActionButton.js
+++ b/src/components/plant/ActionButton.js
@@ -212,6 +212,7 @@ const styles = StyleSheet.create({
     borderRadius: Radii.pill,
     paddingHorizontal: Spacing.base,
     paddingVertical: Spacing.small,
+    minHeight: Spacing.xlarge + Spacing.small,
     ...Elevation.raised,
   },
   icon: {

--- a/src/components/plant/BuffsBar.js
+++ b/src/components/plant/BuffsBar.js
@@ -2,14 +2,20 @@
 // Afecta: PlantScreen (barra de buffs)
 // Propósito: gestionar y mostrar chips de buffs con temporizador compartido
 // Puntos de edición futura: extracción a contexto o data real
-// Autor: Codex - Fecha: 2025-08-18
+// Autor: Codex - Fecha: 2025-08-16
 
 import React, { useCallback, useEffect, useState } from "react";
 import { ScrollView, View, StyleSheet, Text } from "react-native";
 import BuffChip from "./BuffChip";
 import { Colors, Spacing, Typography, Opacity } from "../../theme";
 
-export default function BuffsBar({ buffs, onExpire, horizontal = true }) {
+export default function BuffsBar({
+  buffs,
+  onExpire,
+  horizontal = true,
+  contentContainerStyle,
+  style,
+}) {
   // [MB] Estado local para manejar ms restantes de cada buff
   const [buffsState, setBuffsState] = useState(() => buffs.map((b) => ({ ...b })));
 
@@ -53,22 +59,30 @@ export default function BuffsBar({ buffs, onExpire, horizontal = true }) {
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}
-        contentContainerStyle={styles.row}
+        contentContainerStyle={[styles.row, contentContainerStyle]}
+        style={[styles.container, style]}
       >
         {content}
       </ScrollView>
     );
   }
 
-  return <View style={[styles.row, styles.wrap]}>{content}</View>;
+  return (
+    <View style={[styles.row, styles.wrap, styles.container, contentContainerStyle, style]}>
+      {content}
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    opacity: Opacity.muted + 0.2,
+    marginVertical: Spacing.base,
+  },
   row: {
     flexDirection: "row",
     alignItems: "center",
-    gap: Spacing.small,
-    paddingVertical: Spacing.small,
+    gap: Spacing.base,
   },
   wrap: {
     flexWrap: "wrap",

--- a/src/components/plant/CareMetrics.js
+++ b/src/components/plant/CareMetrics.js
@@ -105,6 +105,7 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: "row",
     flexWrap: "wrap",
+    alignSelf: "stretch",
   },
 });
 

--- a/src/components/plant/GrowthProgress.js
+++ b/src/components/plant/GrowthProgress.js
@@ -2,7 +2,7 @@
 // Afecta: PlantScreen (barra y log)
 // Propósito: mostrar etapa actual, progreso animado y últimos hitos
 // Puntos de edición futura: extraer colores de stage y consolidar estilos
-// Autor: Codex - Fecha: 2025-08-18
+// Autor: Codex - Fecha: 2025-08-16
 
 import React, { useEffect, useRef, useState } from "react";
 import {
@@ -13,14 +13,8 @@ import {
   Easing,
 } from "react-native";
 import GrowthMilestoneItem from "./GrowthMilestoneItem";
-import {
-  Colors,
-  Spacing,
-  Radii,
-  Elevation,
-  Typography,
-  Opacity,
-} from "../../theme";
+import Divider from "../ui/Divider";
+import { Colors, Spacing, Radii, Typography, Opacity } from "../../theme";
 
 // [MB] Acentos para crecimiento
 const ElementAccents = {
@@ -40,8 +34,8 @@ function getStageVisual(stage) {
 export default function GrowthProgress({
   stage,
   progress,
-  etaText,
   milestones = [],
+  limitLog = 5,
   style,
 }) {
   const { emoji, accentKey } = getStageVisual(stage);
@@ -102,9 +96,6 @@ export default function GrowthProgress({
 
   return (
     <View style={[styles.container, style]}>
-      <Text style={styles.sectionTitle} accessibilityRole="header">
-        Progreso de crecimiento
-      </Text>
       {/* [MB] Etapa actual con badge y porcentaje */}
       <View style={styles.header} accessible accessibilityLabel={accessibleStage}>
         <View style={styles.badgeWrapper}>
@@ -130,7 +121,7 @@ export default function GrowthProgress({
       >
         <Animated.View style={[styles.barFill, { backgroundColor: accent, width: barWidth }]} />
       </View>
-      {etaText ? <Text style={styles.eta}>{etaText}</Text> : null}
+      {milestones.length > 0 && <Divider style={styles.divider} />}
       <View style={styles.milestones}>
         {milestones.length === 0 ? (
           <View style={styles.empty}>
@@ -138,7 +129,9 @@ export default function GrowthProgress({
             <Text style={styles.emptyText}>Sin eventos recientes</Text>
           </View>
         ) : (
-          milestones.slice(0, 5).map((m) => <GrowthMilestoneItem key={m.id} {...m} />)
+          milestones
+            .slice(0, limitLog)
+            .map((m) => <GrowthMilestoneItem key={m.id} {...m} />)
         )}
       </View>
     </View>
@@ -147,16 +140,8 @@ export default function GrowthProgress({
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: Colors.surfaceElevated,
-    padding: Spacing.large,
-    borderRadius: Radii.lg,
-    ...Elevation.card,
     alignSelf: "stretch",
-  },
-  sectionTitle: {
-    ...Typography.title,
-    color: Colors.text,
-    marginBottom: Spacing.base,
+    gap: Spacing.base,
   },
   header: {
     flexDirection: "row",
@@ -198,24 +183,20 @@ const styles = StyleSheet.create({
   },
   barTrack: {
     // [MB] Track con surfaceAlt (no existe surfaceVariant)
-    height: Spacing.small,
+    height: Spacing.small + Spacing.tiny,
     borderRadius: Radii.pill,
     backgroundColor: Colors.surfaceAlt,
-    marginTop: Spacing.base,
     overflow: "hidden",
   },
   barFill: {
     height: "100%",
     borderRadius: Radii.pill,
   },
-  eta: {
-    ...Typography.caption,
-    color: Colors.text,
-    opacity: Opacity.muted,
-    marginTop: Spacing.small,
+  divider: {
+    marginTop: Spacing.base,
   },
   milestones: {
-    marginTop: Spacing.large,
+    marginTop: Spacing.base,
   },
   empty: {
     alignItems: "center",

--- a/src/components/plant/HealthChip.js
+++ b/src/components/plant/HealthChip.js
@@ -2,7 +2,7 @@
 // Afecta: PlantScreen (cabecera con salud)
 // Propósito: chip de salud derivada de agua/luz/nutrientes
 // Puntos de edición futura: estados de color o layout
-// Autor: Codex - Fecha: 2025-08-16
+// Autor: Codex - Fecha: 2025-08-17
 
 import React from "react";
 import { View, Text, StyleSheet } from "react-native";
@@ -27,12 +27,13 @@ export default function HealthChip({ value }) {
   const pct = Math.round(v * 100);
   const state = getState(v);
   const chipOpacity = state === "LOW" ? 0.6 : state === "OK" ? 0.85 : 1;
+  const accent = ElementAccents.health;
 
   return (
     <View
       accessibilityRole="text"
       accessibilityLabel={`Salud ${pct} %, estado ${state}`}
-      style={[styles.chip, { backgroundColor: ElementAccents.health, opacity: chipOpacity }]}
+      style={[styles.chip, { borderColor: accent, opacity: chipOpacity }]}
     >
       <Text style={styles.icon}>❤️</Text>
       <Text style={styles.label}>Salud</Text>
@@ -56,23 +57,24 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     borderRadius: Radii.pill,
-    paddingHorizontal: Spacing.base,
-    paddingVertical: Spacing.small,
+    paddingHorizontal: Spacing.small,
+    paddingVertical: Spacing.tiny,
+    backgroundColor: Colors.surfaceAlt,
+    borderWidth: 1,
     ...Elevation.raised,
   },
   icon: {
-    marginRight: Spacing.small,
+    marginRight: Spacing.tiny,
   },
   label: {
     ...Typography.caption,
-    color: Colors.textInverse,
-    opacity: Opacity.muted,
-    marginRight: Spacing.small,
+    color: Colors.textMuted,
+    marginRight: Spacing.tiny,
   },
   value: {
-    ...Typography.body,
+    ...Typography.caption,
     fontWeight: "700",
-    color: Colors.textInverse,
+    color: Colors.text,
   },
 });
 

--- a/src/components/plant/MetricPill.js
+++ b/src/components/plant/MetricPill.js
@@ -114,7 +114,7 @@ const styles = StyleSheet.create({
   track: {
     position: "relative",
     justifyContent: "center",
-    height: Spacing.large,
+    height: Spacing.xlarge + Spacing.small,
     borderRadius: Radii.pill,
     backgroundColor: Colors.surfaceAlt,
     overflow: "hidden",
@@ -134,15 +134,16 @@ const styles = StyleSheet.create({
   left: {
     flexDirection: "row",
     alignItems: "center",
+    gap: Spacing.small,
   },
   label: {
     ...Typography.body,
     color: Colors.text,
-    marginLeft: Spacing.small,
   },
   value: {
     ...Typography.caption,
     color: Colors.textMuted,
+    textAlign: "right",
   },
 });
 

--- a/src/components/plant/MoodChip.js
+++ b/src/components/plant/MoodChip.js
@@ -2,7 +2,7 @@
 // Afecta: PlantScreen (cabecera con ánimo)
 // Propósito: chip de ánimo opcional
 // Puntos de edición futura: estados de color o layout
-// Autor: Codex - Fecha: 2025-08-16
+// Autor: Codex - Fecha: 2025-08-17
 
 import React from "react";
 import { View, Text, StyleSheet } from "react-native";
@@ -34,6 +34,7 @@ export default function MoodChip({ value }) {
     : state === "OK"
     ? 0.85
     : 1;
+  const accent = ElementAccents.spirit;
 
   return (
     <View
@@ -41,7 +42,7 @@ export default function MoodChip({ value }) {
       accessibilityLabel={
         hasValue ? `Ánimo ${pct} %, estado ${state}` : "Ánimo sin datos"
       }
-      style={[styles.chip, { backgroundColor: ElementAccents.spirit, opacity: chipOpacity }]}
+      style={[styles.chip, { borderColor: accent, opacity: chipOpacity }]}
     >
       <Text style={styles.icon}>🧘</Text>
       <Text style={styles.label}>Ánimo</Text>
@@ -65,23 +66,24 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     borderRadius: Radii.pill,
-    paddingHorizontal: Spacing.base,
-    paddingVertical: Spacing.small,
+    paddingHorizontal: Spacing.small,
+    paddingVertical: Spacing.tiny,
+    backgroundColor: Colors.surfaceAlt,
+    borderWidth: 1,
     ...Elevation.raised,
   },
   icon: {
-    marginRight: Spacing.small,
+    marginRight: Spacing.tiny,
   },
   label: {
     ...Typography.caption,
-    color: Colors.textInverse,
-    opacity: Opacity.muted,
-    marginRight: Spacing.small,
+    color: Colors.textMuted,
+    marginRight: Spacing.tiny,
   },
   value: {
-    ...Typography.body,
+    ...Typography.caption,
     fontWeight: "700",
-    color: Colors.textInverse,
+    color: Colors.text,
   },
 });
 

--- a/src/components/plant/PlantHeader.js
+++ b/src/components/plant/PlantHeader.js
@@ -2,7 +2,7 @@
 // Afecta: PlantScreen (cabecera principal)
 // Propósito: agrupar nombre editable, salud/ánimo y economía
 // Puntos de edición futura: mover cálculo de salud o estilos a .styles.js
-// Autor: Codex - Fecha: 2025-08-16
+// Autor: Codex - Fecha: 2025-08-17
 
 import React, { useState, useRef } from "react";
 import {
@@ -129,24 +129,19 @@ export default function PlantHeader({
         </View>
         <View style={styles.chips}>
           <HealthChip value={health} />
-          <View style={{ width: Spacing.base }} />
           <MoodChip value={mood} />
         </View>
       </View>
       <View style={styles.bottomRow}>
         {/* [MB] Economía reubicada dentro del header */}
-        <View style={styles.capsules}>
-          <ResourceCapsules
-            mana={mana}
-            coins={coins}
-            gems={gems}
-            txn={txn}
-            insufficient={insufficient}
-          />
-        </View>
-        <View style={styles.streakItem}>
-          <StreakChip days={streakDays} />
-        </View>
+        <ResourceCapsules
+          mana={mana}
+          coins={coins}
+          gems={gems}
+          txn={txn}
+          insufficient={insufficient}
+        />
+        <StreakChip days={streakDays} />
       </View>
     </View>
   );
@@ -190,19 +185,14 @@ const styles = StyleSheet.create({
   chips: {
     flexDirection: "row",
     alignItems: "center",
+    gap: Spacing.small,
   },
   bottomRow: {
     flexDirection: "row",
     flexWrap: "wrap",
     alignItems: "center",
     marginTop: Spacing.base,
-  },
-  capsules: {
-    marginRight: Spacing.base,
-    marginBottom: Spacing.small,
-  },
-  streakItem: {
-    marginBottom: Spacing.small,
+    gap: Spacing.small,
   },
 });
 

--- a/src/components/plant/PlantHero.js
+++ b/src/components/plant/PlantHero.js
@@ -6,7 +6,7 @@
 
 import React, { useEffect, useRef } from "react";
 import { View, Text, Image, Animated, Easing, StyleSheet } from "react-native";
-import { Colors, Spacing, Elevation } from "../../theme";
+import { Colors, Spacing } from "../../theme";
 
 // [MB] Mapa de tamaños derivado de Spacing
 const SIZE_MAP = {
@@ -17,6 +17,7 @@ const SIZE_MAP = {
 export default function PlantHero({
   source,
   size = "lg",
+  auraIntensity = "default",
   health,
   mood,
   stage,
@@ -47,40 +48,44 @@ export default function PlantHero({
     return () => loop.stop();
   }, [anim]);
 
-  const baseSize = SIZE_MAP[size] || SIZE_MAP.lg;
+  const baseSize = (SIZE_MAP[size] || SIZE_MAP.lg) * (auraIntensity === "subtle" ? 0.9 : 1);
   const scale = anim.interpolate({ inputRange: [0, 1], outputRange: [1, 1.03] });
-  const auraOpacity = anim.interpolate({ inputRange: [0, 1], outputRange: [0.12, 0.22] });
-  const auraSizeOuter = baseSize * 1.6;
+  const auraOpacity = anim.interpolate({
+    inputRange: [0, 1],
+    outputRange: auraIntensity === "subtle" ? [0.08, 0.16] : [0.12, 0.22],
+  });
+  const auraSizeOuter = baseSize * (auraIntensity === "subtle" ? 1.4 : 1.6);
   const auraSizeInner = baseSize * 1.3;
 
   const label = `Planta ${stage}; salud ${Math.round(health * 100)}%; ánimo ${mood}`;
 
   return (
     <View style={[styles.container, style]}>
-      {/* [MB] Aura exterior */}
+      {auraIntensity !== "subtle" && (
+        <Animated.View
+          pointerEvents="none"
+          style={[
+            styles.aura,
+            {
+              width: auraSizeOuter,
+              height: auraSizeOuter,
+              borderRadius: auraSizeOuter / 2,
+              backgroundColor: Colors.primaryFantasy,
+              opacity: auraOpacity,
+              transform: [{ scale }],
+            },
+          ]}
+        />
+      )}
       <Animated.View
         pointerEvents="none"
         style={[
           styles.aura,
           {
-            width: auraSizeOuter,
-            height: auraSizeOuter,
-            borderRadius: auraSizeOuter / 2,
-            backgroundColor: Colors.primaryFantasy,
-            opacity: auraOpacity,
-            transform: [{ scale }],
-          },
-        ]}
-      />
-      {/* [MB] Aura interior */}
-      <Animated.View
-        pointerEvents="none"
-        style={[
-          styles.aura,
-          {
-            width: auraSizeInner,
-            height: auraSizeInner,
-            borderRadius: auraSizeInner / 2,
+            width: auraIntensity === "subtle" ? auraSizeOuter : auraSizeInner,
+            height: auraIntensity === "subtle" ? auraSizeOuter : auraSizeInner,
+            borderRadius:
+              (auraIntensity === "subtle" ? auraSizeOuter : auraSizeInner) / 2,
             backgroundColor: Colors.secondaryFantasy,
             opacity: auraOpacity,
             transform: [{ scale }],
@@ -146,10 +151,8 @@ const styles = StyleSheet.create({
   container: {
     alignItems: "center",
     justifyContent: "center",
-    padding: Spacing.large,
-    backgroundColor: Colors.surfaceElevated,
-    borderRadius: Spacing.large,
-    ...Elevation.card,
+    alignSelf: "center",
+    marginVertical: Spacing.large,
   },
   aura: {
     position: "absolute",

--- a/src/components/plant/QuickActions.js
+++ b/src/components/plant/QuickActions.js
@@ -42,17 +42,6 @@ export default function QuickActions({
       cooldown: cooldowns.feed || 0,
     },
     {
-      key: "clean",
-      title: "Limpiar",
-      icon: <Text>🧼</Text>,
-      accentKey: "clean",
-      costLabel: undefined,
-      tooltip: "+10 Pureza",
-      hint: "Quita impurezas",
-      enabled: canClean,
-      cooldown: cooldowns.clean || 0,
-    },
-    {
       key: "meditate",
       title: "Meditar",
       icon: <Text>🧘‍♂️</Text>,
@@ -62,6 +51,17 @@ export default function QuickActions({
       hint: "Relaja el espíritu",
       enabled: canMeditate,
       cooldown: cooldowns.meditate || 0,
+    },
+    {
+      key: "clean",
+      title: "Limpiar",
+      icon: <Text>🧼</Text>,
+      accentKey: "clean",
+      costLabel: undefined,
+      tooltip: "+10 Pureza",
+      hint: "Quita impurezas",
+      enabled: canClean,
+      cooldown: cooldowns.clean || 0,
     },
   ];
 
@@ -92,12 +92,11 @@ const styles = StyleSheet.create({
     flexWrap: "wrap",
     justifyContent: "space-between",
     alignSelf: "stretch",
-    marginTop: Spacing.large,
-    marginBottom: Spacing.large,
+    rowGap: Spacing.base,
+    columnGap: Spacing.base,
   },
   item: {
     flexBasis: "48%",
-    marginBottom: Spacing.base,
   },
 });
 

--- a/src/components/ui/Divider.js
+++ b/src/components/ui/Divider.js
@@ -1,0 +1,22 @@
+// [MB] Módulo: UI / Sección: Wrappers
+// Afecta: PlantScreen (divisiones)
+// Propósito: separar contenido con una línea sutil
+// Puntos de edición futura: grosor y orientación
+// Autor: Codex - Fecha: 2025-08-16
+
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { Colors, Opacity, Spacing } from "../../theme";
+
+export default function Divider({ style }) {
+  return <View style={[styles.divider, style]} />;
+}
+
+const styles = StyleSheet.create({
+  divider: {
+    height: Spacing.tiny / 2,
+    backgroundColor: Colors.text,
+    opacity: Opacity.muted,
+    alignSelf: "stretch",
+  },
+});

--- a/src/components/ui/ScreenSection.js
+++ b/src/components/ui/ScreenSection.js
@@ -1,0 +1,23 @@
+// [MB] Módulo: UI / Sección: Wrappers
+// Afecta: PlantScreen (secciones)
+// Propósito: contenedor de sección con fondo elevado y padding
+// Puntos de edición futura: mover a styles si crece
+// Autor: Codex - Fecha: 2025-08-16
+
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { Colors, Spacing, Radii, Elevation } from "../../theme";
+
+export default function ScreenSection({ children, style }) {
+  return <View style={[styles.section, style]}>{children}</View>;
+}
+
+const styles = StyleSheet.create({
+  section: {
+    backgroundColor: Colors.surfaceElevated,
+    padding: Spacing.large,
+    borderRadius: Radii.xl,
+    ...Elevation.card,
+    alignSelf: "stretch",
+  },
+});

--- a/src/components/ui/SectionHeader.js
+++ b/src/components/ui/SectionHeader.js
@@ -1,0 +1,35 @@
+// [MB] Módulo: UI / Sección: Wrappers
+// Afecta: PlantScreen (encabezados de sección)
+// Propósito: título y caption opcional para secciones
+// Puntos de edición futura: variantes de tipografía
+// Autor: Codex - Fecha: 2025-08-16
+
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { Typography, Colors, Spacing, Opacity } from "../../theme";
+
+export default function SectionHeader({ title, caption }) {
+  return (
+    <View accessibilityRole="header" style={styles.container}>
+      <Text style={styles.title}>{title}</Text>
+      {caption ? <Text style={styles.caption}>{caption}</Text> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: Spacing.base,
+    gap: Spacing.tiny,
+  },
+  title: {
+    ...Typography.title,
+    color: Colors.text,
+    fontWeight: "600",
+  },
+  caption: {
+    ...Typography.caption,
+    color: Colors.text,
+    opacity: Opacity.muted,
+  },
+});

--- a/src/screens/PlantScreen.js
+++ b/src/screens/PlantScreen.js
@@ -13,6 +13,8 @@ import GrowthProgress from "../components/plant/GrowthProgress";
 import BuffsBar from "../components/plant/BuffsBar";
 import InventorySheet from "../components/plant/InventorySheet";
 import PlantHeader from "../components/plant/PlantHeader";
+import ScreenSection from "../components/ui/ScreenSection";
+import SectionHeader from "../components/ui/SectionHeader";
 import { Colors, Spacing } from "../theme";
 
 const ElementAccents = {
@@ -40,6 +42,8 @@ export default function PlantScreen() {
 
   const equippedSkin = skins.find((s) => s.id === equippedSkinId);
   const skinAccent = equippedSkin ? ElementAccents[equippedSkin.accentKey] : undefined;
+
+  const etaText = "faltan ~3 tareas";
 
   // [MB] Costos mock por acción (solo UI)
   const ACTION_COSTS = {
@@ -88,7 +92,6 @@ export default function PlantScreen() {
 
   return (
     <SafeAreaView style={styles.safeArea}>
-      {/* [MB] Contenido scrollable para evitar notch y reservar espacio para FAB */}
       <ScrollView
         contentContainerStyle={styles.content}
         importantForAccessibility={invOpen ? "no-hide-descendants" : "auto"}
@@ -107,45 +110,14 @@ export default function PlantScreen() {
           txn={txn}
           insufficient={insufficient}
         />
-        {/* [MB] Hero de planta con overlay de maceta */}
-        <PlantHero health={0.95} mood="floreciente" stage="brote" skinAccent={skinAccent} />
-        {/* [MB] Métricas de cuidado */}
-        <CareMetrics
-          water={0.62}
-          light={0.48}
-          nutrients={0.3}
-          mood={0.95}
-          style={{ alignSelf: "stretch", marginTop: Spacing.large }}
-        />
-        {/* [MB] Acciones rápidas de cuidado */}
-        <QuickActions
-          canWater
-          canFeed
-          canClean
-          canMeditate
-          cooldowns={{ water: 0, feed: 0, clean: 0, meditate: 0 }}
-          onAction={(key) => {
-            if (key === "clean") {
-              setSelectedSkinId(equippedSkinId);
-              setInvOpen(true);
-              return;
-            }
-            handleAction(key);
-          }}
-        />
-        {/* [MB] Progreso de crecimiento */}
-        <GrowthProgress
+        <PlantHero
+          health={0.95}
+          mood="floreciente"
           stage="brote"
-          progress={0.62}
-          etaText="faltan ~3 tareas"
-          milestones={[
-            { id: "m1", icon: "💧", title: "Regaste", delta: "+15 Agua", timestamp: Date.now() - 1000 * 60 * 20 },
-            { id: "m2", icon: "🍃", title: "Aplicaste nutrientes", delta: "+10 Nutrientes", timestamp: Date.now() - 1000 * 60 * 90 },
-            { id: "m3", icon: "🧘", title: "Meditaste", delta: "+10 Ánimo", timestamp: Date.now() - 1000 * 60 * 200 },
-          ]}
-          style={{ alignSelf: "stretch", marginTop: Spacing.large }}
+          skinAccent={skinAccent}
+          auraIntensity="subtle"
+          size="lg"
         />
-        {/* [MB] Barra de buffs activos (mock) */}
         <BuffsBar
           buffs={[
             { id: "b1", title: "XP", icon: "✨", multiplier: 1.2, timeRemainingMs: 120000, accentKey: "xp" },
@@ -153,7 +125,48 @@ export default function PlantScreen() {
             { id: "b3", title: "Protección", icon: "🛡️", multiplier: 1.0, timeRemainingMs: 300000, accentKey: "shield" },
           ]}
           onExpire={(id) => console.log("[MB] buff expirado:", id)}
+          contentContainerStyle={{ gap: Spacing.base }}
         />
+        <ScreenSection>
+          <SectionHeader title="Métricas de cuidado" />
+          <CareMetrics
+            water={0.62}
+            light={0.48}
+            nutrients={0.3}
+            mood={0.95}
+          />
+        </ScreenSection>
+        <ScreenSection>
+          <SectionHeader title="Acciones rápidas" />
+          <QuickActions
+            canWater
+            canFeed
+            canClean
+            canMeditate
+            cooldowns={{ water: 0, feed: 0, clean: 0, meditate: 0 }}
+            onAction={(key) => {
+              if (key === "clean") {
+                setSelectedSkinId(equippedSkinId);
+                setInvOpen(true);
+                return;
+              }
+              handleAction(key);
+            }}
+          />
+        </ScreenSection>
+        <ScreenSection>
+          <SectionHeader title="Progreso de crecimiento" caption={etaText} />
+          <GrowthProgress
+            stage="brote"
+            progress={0.62}
+            milestones={[
+              { id: "m1", icon: "💧", title: "Regaste", delta: "+15 Agua", timestamp: Date.now() - 1000 * 60 * 20 },
+              { id: "m2", icon: "🍃", title: "Aplicaste nutrientes", delta: "+10 Nutrientes", timestamp: Date.now() - 1000 * 60 * 90 },
+              { id: "m3", icon: "🧘", title: "Meditaste", delta: "+10 Ánimo", timestamp: Date.now() - 1000 * 60 * 200 },
+            ]}
+            limitLog={3}
+          />
+        </ScreenSection>
       </ScrollView>
       <InventorySheet
         visible={invOpen}
@@ -181,7 +194,7 @@ const styles = StyleSheet.create({
   content: {
     padding: Spacing.large,
     paddingBottom: Spacing.large * 3,
-    alignItems: "center",
+    gap: Spacing.xlarge,
   },
 });
 


### PR DESCRIPTION
## Summary
- add ScreenSection, SectionHeader and Divider wrappers to unify card layout and section headings
- streamline PlantScreen hierarchy with subtle hero, muted buffs and carded metrics/actions/progress sections
- standardize pill and button dimensions while enhancing GrowthProgress with thicker bar and limited milestone log
- tidy PlantHeader layout with gap-based rows and compact theme-colored chips

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ff3e2545c832793ab25950c18412d