### PR TITLE
feat(home): show resource capsules and streak chip

### DIFF
--- a/src/components/home/HomeHeader.js
+++ b/src/components/home/HomeHeader.js
@@ -2,7 +2,7 @@
 // Afecta: HomeScreen
 // Propósito: Encabezado con top bar, chips y popovers informativos
 // Puntos de edición futura: conectar datos reales y estilos responsivos
-// Autor: Codex - Fecha: 2025-08-16
+// Autor: Codex - Fecha: 2025-08-17
 
 import React, {
   useState,
@@ -21,10 +21,11 @@ import {
   Platform,
 } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
-import { useNavigation } from "@react-navigation/native";
 
 import styles from "./HomeHeader.styles";
 import { Gradients, Spacing } from "../../theme";
+import ResourceCapsules from "../economy/ResourceCapsules";
+import StreakChip from "../economy/StreakChip";
 import {
   useAppState,
   useWallet,
@@ -52,7 +53,6 @@ function HomeHeader(
   const { coin, gem } = useWallet();
   const { level, progress } = useProgress();
   const buffs = useActiveBuffs();
-  const navigation = useNavigation();
 
   const [activeChip, setActiveChip] = useState(null);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
@@ -116,65 +116,7 @@ function HomeHeader(
       desc: `Estado actual: ${plantState || "Floreciendo"}.`,
       a11y: "Estado de planta",
     },
-    mana: {
-      key: "mana",
-      label: "Maná",
-      title: "Maná",
-      desc: `Tienes ${mana} de maná disponible.`,
-      a11y: "Maná",
-    },
-    coins: {
-      key: "coins",
-      label: "Monedas",
-      title: "Monedas",
-      desc: `Tienes ${coin} monedas.`,
-      a11y: "Monedas",
-    },
-    diamonds: {
-      key: "diamonds",
-      label: "Diamantes",
-      title: "Diamantes",
-      desc: `Tienes ${gem} diamantes.`,
-      a11y: "Diamantes",
-    },
-    streak: {
-      key: "streak",
-      label: "Racha",
-      title: "Racha",
-      desc: `Racha activa de ${streak} días.`,
-      a11y: "Racha activa",
-    },
-    buffs: {
-      key: "buffs",
-      label: "Buffs",
-      title: "Buffs",
-      desc: buffs.length
-        ? `${buffs.length} buffs activos.`
-        : "Sin buffs activos.",
-      a11y: "Buffs activos",
-    },
-    rewards: {
-      key: "rewards",
-      label: "Recompensas",
-      title: "Recompensas",
-      desc: "Explora recompensas disponibles.",
-      a11y: "Recompensas",
-      accent: true,
-      onPress: () => {
-        closePopover();
-        navigation.navigate("Rewards");
-      },
-    },
   };
-
-  const rowChips = [
-    "mana",
-    "coins",
-    "diamonds",
-    "streak",
-    "buffs",
-    "rewards",
-  ];
 
   useEffect(() => {
     if (activeChip) {
@@ -244,55 +186,29 @@ function HomeHeader(
         </Pressable>
       </View>
 
-      <View style={styles.chipBlock}>
-        <View style={styles.chipRow}>
-          {rowChips.map((key) => {
-            const c = chipConfig[key];
-            return (
-              <Pressable
-                key={c.key}
-                onPress={c.onPress ? c.onPress : () => onPressChip(c.key)}
-                style={[styles.chip, c.accent && styles.chipAccent]}
-                accessibilityRole="button"
-                accessibilityLabel={c.a11y}
-                accessibilityState={
-                  activeChip === c.key ? { expanded: true } : undefined
-                }
-                hitSlop={chipHitSlop}
-              >
-            <View style={styles.chipContent}>
-              <Text
-                style={c.accent ? styles.chipTextOnAccent : styles.chipText}
-                numberOfLines={1}
-                ellipsizeMode="tail"
-              >
-                {c.label}
-              </Text>
-            </View>
-          </Pressable>
-            );
-          })}
-        </View>
-        {isPopoverOpen && (
-          <Animated.View
-            style={[styles.popoverContainer, animatedStyle]}
-            accessibilityViewIsModal={true}
-          >
-            <Animated.View style={{ opacity: contentOpacity }}>
-              {activeChip && (
-                <>
-                  <Text ref={popoverTitleRef} style={styles.popoverTitle}>
-                    {chipConfig[activeChip].title}
-                  </Text>
-                  <Text style={styles.popoverDesc}>
-                    {chipConfig[activeChip].desc}
-                  </Text>
-                </>
-              )}
-            </Animated.View>
-          </Animated.View>
-        )}
+      <View style={styles.resourcesRow}>
+        <ResourceCapsules mana={mana} coins={coin} gems={gem} />
+        <StreakChip days={streak} />
       </View>
+      {isPopoverOpen && (
+        <Animated.View
+          style={[styles.popoverContainer, animatedStyle]}
+          accessibilityViewIsModal={true}
+        >
+          <Animated.View style={{ opacity: contentOpacity }}>
+            {activeChip && (
+              <>
+                <Text ref={popoverTitleRef} style={styles.popoverTitle}>
+                  {chipConfig[activeChip].title}
+                </Text>
+                <Text style={styles.popoverDesc}>
+                  {chipConfig[activeChip].desc}
+                </Text>
+              </>
+            )}
+          </Animated.View>
+        </Animated.View>
+      )}
 
       <View style={styles.levelRow}>
         <View

--- a/src/components/home/HomeHeader.styles.js
+++ b/src/components/home/HomeHeader.styles.js
@@ -2,7 +2,7 @@
 // Afecta: HomeHeader
 // Propósito: Estilos para top bar, chips y popovers del encabezado
 // Puntos de edición futura: ajustar tamaños de chip y responsividad
-// Autor: Codex - Fecha: 2025-08-16
+// Autor: Codex - Fecha: 2025-08-17
 
 import { StyleSheet } from "react-native";
 import { Colors, Spacing, Radii, Typography, Elevation } from "../../theme";
@@ -54,35 +54,10 @@ export default StyleSheet.create({
     fontWeight: "600",
     color: Colors.text,
   },
-  chipBlock: {
-    marginTop: Spacing.small,
-  },
-  chipRow: {
+  resourcesRow: {
     flexDirection: "row",
-    flexWrap: "wrap",
-    justifyContent: "space-between",
-    alignSelf: "stretch",
-    width: "100%",
-    alignItems: "center",
     gap: Spacing.small,
-    position: "relative",
-    zIndex: 2,
-  },
-  chip: {
-    backgroundColor: Colors.surface,
-    borderRadius: Radii.lg,
-    paddingHorizontal: Spacing.base,
-    paddingVertical: Spacing.small,
-    height: 30,
-    flexBasis: "31%",
-    maxWidth: "31%",
-    flexGrow: 0,
-    marginBottom: Spacing.small,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  chipAccent: {
-    backgroundColor: Colors.accent,
+    marginTop: Spacing.small,
   },
   chipContent: {
     alignItems: "center",
@@ -93,11 +68,6 @@ export default StyleSheet.create({
     ...Typography.caption,
     fontWeight: "600",
     color: Colors.text,
-  },
-  chipTextOnAccent: {
-    ...Typography.caption,
-    fontWeight: "600",
-    color: Colors.onAccent,
   },
   popoverContainer: {
     marginTop: Spacing.small,


### PR DESCRIPTION
## Summary
- replace chip row with ResourceCapsules and StreakChip under the header top bar
- add resourcesRow style for compact band layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ffa3eebd08327b589bf198842094f