### PR TITLE
feat: replace notification text with icon

### DIFF
--- a/src/components/home/HomeHeader.js
+++ b/src/components/home/HomeHeader.js
@@ -21,10 +21,11 @@ import {
   Platform,
 } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
+import { Ionicons } from "@expo/vector-icons";
 import { useNavigation } from "@react-navigation/native";
 
 import styles from "./HomeHeader.styles";
-import { Gradients, Spacing } from "../../theme";
+import { Colors, Gradients, Spacing } from "../../theme";
 import {
   useAppState,
   useWallet,
@@ -240,7 +241,11 @@ function HomeHeader(
           accessibilityRole="button"
           accessibilityLabel="Abrir notificaciones"
         >
-          <Text style={styles.notificationsText}>Notificaciones</Text>
+          <Ionicons
+            name="notifications-outline"
+            size={Spacing.base * 2}
+            color={Colors.text}
+          />
         </Pressable>
       </View>
 

--- a/src/components/home/HomeHeader.styles.js
+++ b/src/components/home/HomeHeader.styles.js
@@ -43,16 +43,10 @@ export default StyleSheet.create({
   notificationsButton: {
     backgroundColor: Colors.surface,
     borderRadius: Radii.lg,
-    paddingHorizontal: Spacing.base,
-    paddingVertical: Spacing.small,
-    height: 30,
+    width: Spacing.base * 2,
+    height: Spacing.base * 2,
     justifyContent: "center",
     alignItems: "center",
-  },
-  notificationsText: {
-    ...Typography.body,
-    fontWeight: "600",
-    color: Colors.text,
   },
   chipBlock: {
     marginTop: Spacing.small,


### PR DESCRIPTION
## Summary
- import Ionicons in home header
- swap notifications text for outline icon
- simplify notification button styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ffa40fc388327a0c719108260ca7a