### PR TITLE
Adjust metric pill height and default icon size

### DIFF
--- a/src/components/plant/MetricPill.js
+++ b/src/components/plant/MetricPill.js
@@ -92,7 +92,10 @@ export default function MetricPill({ icon, label, value, accentKey }) {
       {/* [MB] Contenido textual/iconográfico */}
       <View style={styles.content}>
         <View style={styles.left}>
-          {icon}
+          {icon &&
+            React.cloneElement(icon, {
+              size: icon.props?.size ?? Spacing.base,
+            })}
           <Text style={styles.label}>{label}</Text>
         </View>
         <Text style={styles.value}>
@@ -114,7 +117,7 @@ const styles = StyleSheet.create({
   track: {
     position: "relative",
     justifyContent: "center",
-    height: Spacing.xlarge + Spacing.small,
+    height: Spacing.large + Spacing.small,
     borderRadius: Radii.pill,
     backgroundColor: Colors.surfaceAlt,
     overflow: "hidden",


### PR DESCRIPTION
## Summary
- Reduce MetricPill height to `Spacing.large + Spacing.small`
- Default metric icons to `Spacing.base` when size is not provided

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ffa53fbe083278194c57c6b180c03