### PR TITLE
fix: import missing economy components in HomeHeader

### DIFF
--- a/src/components/home/HomeHeader.js
+++ b/src/components/home/HomeHeader.js
@@ -2,7 +2,7 @@
 // Afecta: HomeScreen
 // Propósito: Encabezado con top bar, chips y popovers informativos
 // Puntos de edición futura: conectar datos reales y estilos responsivos
-// Autor: Codex - Fecha: 2025-08-17
+// Autor: Codex - Fecha: 2025-08-16
 
 import React, {
   useState,
@@ -33,6 +33,9 @@ import {
   useProgress,
   useActiveBuffs,
 } from "../../state/AppContext";
+
+import ResourceCapsules from "../economy/ResourceCapsules";
+import StreakChip from "../economy/StreakChip";
 
 const chipHitSlop = {
   top: Spacing.small,


### PR DESCRIPTION
## Summary
- import ResourceCapsules and StreakChip in HomeHeader to render resources properly

## Testing
- `npm test`
- `npm run web` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689ffc55acd88327bce2cc5803280c4c