### PR TITLE
fix: complete element data for air in TasksScreen

### DIFF
--- a/src/screens/TasksScreen.js
+++ b/src/screens/TasksScreen.js
@@ -170,6 +170,10 @@ const elementInfo = {
       "Plan de estudio",
       "Documentar decisiones",
     ],
+    purpose:
+      'Propósito: "Ofrece claridad y ligereza para que la planta se expanda."',
+  },
+};
 
 export default function TasksScreen() {
   const dispatch = useAppDispatch();


### PR DESCRIPTION
## Summary
- close `elementInfo` object and add missing purpose for air element

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ffde33bf88327b0bebd02ebe3545e