### PR TITLE
Fix HomeScreen tasks navigation route

### DIFF
--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -54,7 +54,7 @@ export default function HomeScreen() {
   }, [anchors.shop]);
 
   const goToTasks = useCallback(() => {
-    navigation.navigate("Tasks");
+    navigation.navigate("TasksScreen");
   }, [navigation]);
 
   const handleClaimReward = useCallback(() => {


### PR DESCRIPTION
## Summary
- update HomeScreen's goToTasks handler to navigate to the TasksScreen route defined in App.js

## Testing
- npm test
- npm run web *(fails: Expo CLI cannot fetch dependency metadata in this offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e51473191483278d44dbb273224394