### PR TITLE
Update shop screen hydration placeholder logic

### DIFF
--- a/src/screens/ShopScreen.js
+++ b/src/screens/ShopScreen.js
@@ -60,7 +60,7 @@ export default function ShopScreen() {
   const wallet = useWallet();
   const dispatch = useAppDispatch();
   const canAffordMana = useCanAfford();
-  const hydration = useHydrationStatus();
+  const { modules } = useHydrationStatus();
 
   const canAffordCurrency = useCallback(
     (currency, amount) => wallet[currency] >= amount,
@@ -157,7 +157,7 @@ export default function ShopScreen() {
   const data =
     activeTab === "subs" ? SUBSCRIPTION_PLANS : SHOP_CATALOG[activeTab];
 
-  if (hydration.mana || hydration.wallet) {
+  if (modules.wallet) {
     return (
       <SafeAreaView style={styles.container}>
         <SectionPlaceholder height={300} />


### PR DESCRIPTION
## Summary
- read hydration status modules in the shop screen instead of deprecated fields
- keep the shop placeholder visible while the wallet module hydrates

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e521b182c88327a20632eee6d66367